### PR TITLE
[#3] Badge component 구현

### DIFF
--- a/src/components/badge/badge-type.js
+++ b/src/components/badge/badge-type.js
@@ -1,0 +1,8 @@
+const BADGE_TYPE = Object.freeze({
+  acquaintance: "acquaintance",
+  coworker: "coworker",
+  family: "family",
+  friend: "friend",
+});
+
+export default BADGE_TYPE;

--- a/src/components/badge/badge.jsx
+++ b/src/components/badge/badge.jsx
@@ -1,0 +1,44 @@
+import styled from "styled-components";
+import BADGE_TYPE from "./badge-type";
+
+const styles = {
+  [BADGE_TYPE.acquaintance]: {
+    backgroundColor: "var(--color-beige-100)",
+    color: "var(--color-beige-500)",
+  },
+  [BADGE_TYPE.coworker]: {
+    backgroundColor: "var(--color-purple-100)",
+    color: "var(--color-purple-600)",
+  },
+  [BADGE_TYPE.family]: {
+    backgroundColor: "var(--color-green-100)",
+    color: "var(--color-green-500)",
+  },
+  [BADGE_TYPE.friend]: {
+    backgroundColor: "var(--color-blue-100)",
+    color: "var(--color-blue-500)",
+  },
+};
+
+const title = {
+  [BADGE_TYPE.acquaintance]: "지인",
+  [BADGE_TYPE.coworker]: "동료",
+  [BADGE_TYPE.family]: "가족",
+  [BADGE_TYPE.friend]: "친구",
+};
+
+const StyledBadge = styled.div`
+  background-color: ${({ $type }) => styles[$type].backgroundColor};
+  color: ${({ $type }) => styles[$type].color};
+  border-radius: 4px;
+  padding: 0 8px;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 20px;
+`;
+
+function Badge({ type }) {
+  return <StyledBadge $type={type}>{title[type]}</StyledBadge>;
+}
+
+export default Badge;

--- a/src/components/badge/emoji-badge.jsx
+++ b/src/components/badge/emoji-badge.jsx
@@ -1,0 +1,29 @@
+import styled from "styled-components";
+
+const StyledEmojiBadge = styled.div`
+  background-color: rgba(0, 0, 0, 0.54);
+  color: white;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 20px;
+  padding: 8px 12px;
+  border-radius: 32px;
+`;
+
+const Content = styled.div`
+  display: flex;
+  gap: 4px;
+`;
+
+function EmojiBadge({ emoji, count }) {
+  return (
+    <StyledEmojiBadge>
+      <Content>
+        <span>{emoji}</span>
+        <span>{count}</span>
+      </Content>
+    </StyledEmojiBadge>
+  );
+}
+
+export default EmojiBadge;

--- a/src/pages/test-page.jsx
+++ b/src/pages/test-page.jsx
@@ -1,6 +1,7 @@
 import smileAddImg from "../assets/ic-face-smile-add.svg";
 import Badge from "../components/badge/badge";
 import BADGE_TYPE from "../components/badge/badge-type";
+import EmojiBadge from "../components/badge/emoji-badge";
 import ArrowButton from "../components/button/arrow-button";
 import ARROW_BUTTON_DIRECTION from "../components/button/arrow-button-direction";
 import {
@@ -95,6 +96,12 @@ function TestPage() {
         <Badge type={BADGE_TYPE.coworker} />
         <Badge type={BADGE_TYPE.family} />
         <Badge type={BADGE_TYPE.friend} />
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
+        <EmojiBadge emoji="😚" count={1} />
+        <EmojiBadge emoji="😁" count={10} />
+        <EmojiBadge emoji="😉" count={100} />
+        <EmojiBadge emoji="😊" count={1000} />
       </div>
     </div>
   );

--- a/src/pages/test-page.jsx
+++ b/src/pages/test-page.jsx
@@ -1,4 +1,6 @@
 import smileAddImg from "../assets/ic-face-smile-add.svg";
+import Badge from "../components/badge/badge";
+import BADGE_TYPE from "../components/badge/badge-type";
 import ArrowButton from "../components/button/arrow-button";
 import ARROW_BUTTON_DIRECTION from "../components/button/arrow-button-direction";
 import {
@@ -87,6 +89,12 @@ function TestPage() {
       >
         <ToggleButton options={["컬러", "이미지", "다른값"]} />
         <ToggleButton value="이미지" options={["컬러", "이미지", "다른값"]} />
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
+        <Badge type={BADGE_TYPE.acquaintance} />
+        <Badge type={BADGE_TYPE.coworker} />
+        <Badge type={BADGE_TYPE.family} />
+        <Badge type={BADGE_TYPE.friend} />
       </div>
     </div>
   );


### PR DESCRIPTION
## 📝 작업 내용

- `Badge` component 구현
- `EmojiBadge` component 구현
  - 피그마 시안에 있는 이모지 선택기가 [emoji-picker-react](https://www.npmjs.com/package/emoji-picker-react) 라이브러리에서 제공하는 것과 똑같은 것을 발견했습니다.
    <img width="200" height="619" alt="image" src="https://github.com/user-attachments/assets/f439e193-43b0-4927-93c6-b40e26b20319" />
  - `EmojiBadge`의 `emoji` prop에는 `emoji-picker-react` 라이브러리의 이모지 선택기에서 이모지를 선택했을 때 전달되는 값이 사용될 예정입니다.

## 📷 스크린샷 (선택)

<img width="333" height="97" alt="image" src="https://github.com/user-attachments/assets/717370bb-70c9-4466-a915-751f2fe26a5a" />