### PR TITLE
[#25] 브라우저 창 크기를 변경할 때 dropdown 및 modal layout 갱신

### DIFF
--- a/src/components/modal/modal.jsx
+++ b/src/components/modal/modal.jsx
@@ -168,7 +168,7 @@ const StyledModal = styled.div`
 /* Container */
 
 const ModalContainer = styled.div`
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   right: 0;

--- a/src/hooks/use-dropdown.jsx
+++ b/src/hooks/use-dropdown.jsx
@@ -1,4 +1,4 @@
-import { useContext, useRef, useState } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
 import DropdownContext from "../components/text-field/dropdown-input/dropdown-context";
 
 function makeRect({ x, y, width } = { x: 0, y: 0, width: 0 }) {
@@ -36,11 +36,26 @@ function useDropdown({ id, type }) {
     setDropdownState((prev) => ({ ...prev, [key]: shows }));
   };
 
-  const handleTargetClick = (shows) => {
-    const rect = calculateDropdownRect(targetRef.current);
-    setShowsDropdown(shows);
+  const updateDropdownLayout = (target) => {
+    const rect = calculateDropdownRect(target);
     setDropdownRect(rect);
   };
+
+  const handleTargetClick = (shows) => {
+    updateDropdownLayout(targetRef.current);
+    setShowsDropdown(shows);
+  };
+
+  useEffect(() => {
+    if (!showsDropdown) return;
+
+    function handleWindowResize() {
+      updateDropdownLayout(targetRef.current);
+    }
+
+    window.addEventListener("resize", handleWindowResize);
+    return () => window.removeEventListener("resize", handleWindowResize);
+  }, [showsDropdown, targetRef]);
 
   return {
     targetRef,

--- a/src/pages/test-page.jsx
+++ b/src/pages/test-page.jsx
@@ -44,18 +44,18 @@ function TestPage() {
 
   const handleToastClick = () => setShowsToast(true);
   const handleToastDismiss = () => setShowsToast(false);
-  
+
   /* Modal */
   const { showsModal, setShowsModal } = useModal();
   const handleModalClick = () => setShowsModal(true);
-  
+
   return (
     <div
       style={{
         display: "flex",
         flexDirection: "column",
+        alignItems: "center",
         gap: "16px",
-        margin: 16,
       }}
     >
       <h1>🤯</h1>


### PR DESCRIPTION
## 📝 작업 내용

- 브라우저 창 크기를 변경할 때 dropdown과 modal의 위치 및 크기를 변경된 크기에 맞게 갱신하도록 수정합니다.
- Dropdown은 화면 전체를 덮는 container 안에서 `absolute` position으로 `top`, `left` 값을 설정해서 위치를 결정하기 때문에, 브라우저 창 크기가 변경될 때마다 `resize` event handler에서 dropdown을 trigger한 요소의 위치를 기준으로 dropdown 위치를 다시 계산합니다.
- Modal은 화면 전체를 덮는 container를 `absolute`가 아닌 `fixed` position으로 변경하여, 브라우저 창 크기가 줄어들어 스크롤이 되더라도 항상 브라우저 창 전체를 덮도록 고정합니다.

## 📷 스크린샷 (선택)

다음 순서로 결과물을 직접 확인해 볼 수 있습니다.

1. 제 repository를 remote로 추가합니다. (https://github.com/cskime/rolling.git)
2. 제 repository의 `feature/#25` branch를 checkout 합니다. (local에 같은 이름의 branch 생성)
3. `npm run dev` 명령어로 프로젝트를 실행합니다.
4. `/test-components` path로 이동합니다.
5. 가장 오른쪽에 있는 dropdown `TextField`를 클릭해서 dropdown을 열고 브라우저 창 크기를 바꿔가며 dropdown 위치가 잘 이동하는지 확인합니다.
6. 'Show Modal' 버튼을 클릭해서 modal을 열고 브라우저 창 크기를 바꿔가며 화면 크기가 바뀌거나 scroll 해도 modal이 항상 가운데에 위치하는지 확인합니다.
