### PR TITLE
[#36] Popover component 개발

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
   <body>
     <div id="root"></div>
     <div id="dropdown"></div>
+    <div id="popover"></div>
     <div id="modal"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Route, Routes } from "react-router";
 import ModalProvider from "./components/modal/modal-provider";
+import PopoverProvider from "./components/popover/popover-provider";
 import DropdownProvider from "./components/text-field/dropdown-input/dropdown-provider";
 import ContentLayout from "./layouts/content-layout";
 import OnboardingLayout from "./layouts/onboarding-layout";
@@ -13,7 +14,9 @@ import TestPage from "./pages/test-page";
 function Provider({ children }) {
   return (
     <ModalProvider>
-      <DropdownProvider>{children}</DropdownProvider>
+      <PopoverProvider>
+        <DropdownProvider>{children}</DropdownProvider>
+      </PopoverProvider>
     </ModalProvider>
   );
 }

--- a/src/components/popover/popover-alignment.js
+++ b/src/components/popover/popover-alignment.js
@@ -1,0 +1,6 @@
+const POPOVER_ALIGNMENT = Object.freeze({
+  left: "left",
+  right: "right",
+});
+
+export default POPOVER_ALIGNMENT;

--- a/src/components/popover/popover-context.js
+++ b/src/components/popover/popover-context.js
@@ -1,0 +1,5 @@
+import { createContext } from "react";
+
+const PopoverContext = createContext();
+
+export default PopoverContext;

--- a/src/components/popover/popover-provider.jsx
+++ b/src/components/popover/popover-provider.jsx
@@ -1,0 +1,10 @@
+import { useState } from "react";
+import PopoverContext from "./popover-context";
+
+function PopoverProvider({ children }) {
+  const [showsPopover, setShowsPopover] = useState(false);
+  const value = { showsPopover, setShowsPopover };
+  return <PopoverContext value={value}>{children}</PopoverContext>;
+}
+
+export default PopoverProvider;

--- a/src/components/popover/popover.jsx
+++ b/src/components/popover/popover.jsx
@@ -1,0 +1,39 @@
+import { createPortal } from "react-dom";
+import styled from "styled-components";
+
+const Container = styled.div`
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+`;
+
+function PopoverPortal({ children }) {
+  return createPortal(children, document.getElementById("popover"));
+}
+
+const StyledPopover = styled.div`
+  position: absolute;
+  top: ${({ $position }) => $position.top}px;
+  ${({ $position }) => ($position.left ? `left: ${$position.left}px` : "")};
+  ${({ $position }) => ($position.right ? `right: ${$position.right}px` : "")};
+  border-radius: 8px;
+  border: 1px solid #b6b6b6;
+  background-color: white;
+  box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.08);
+`;
+
+function Popover({ isOpen, onClose, position, children }) {
+  return (
+    isOpen && (
+      <PopoverPortal>
+        <Container onClick={onClose}>
+          <StyledPopover $position={position}>{children}</StyledPopover>
+        </Container>
+      </PopoverPortal>
+    )
+  );
+}
+
+export default Popover;

--- a/src/hooks/use-popover.jsx
+++ b/src/hooks/use-popover.jsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from "react";
+import { useContext, useState, useEffect } from "react";
 import POPOVER_ALIGNMENT from "../components/popover/popover-alignment";
 import PopoverContext from "../components/popover/popover-context";
 
@@ -27,16 +27,35 @@ function calculatePopoverPosition(target, alignment) {
 function usePopover() {
   const { showsPopover, setShowsPopover } = useContext(PopoverContext);
   const [popoverPosition, setPopoverPosition] = useState();
+  const [target, setTarget] = useState();
+  const [alignment, setAlignment] = useState(POPOVER_ALIGNMENT.left);
 
   const openPopopver = ({ target, alignment }) => {
-    const position = calculatePopoverPosition(target, alignment);
+    updatePopoverPosition(target, alignment);
+    setTarget(target);
+    setAlignment(alignment);
     setShowsPopover(true);
-    setPopoverPosition(position);
   };
 
   const closePopover = () => {
     setShowsPopover(false);
   };
+
+  const updatePopoverPosition = (target, alignment) => {
+    const position = calculatePopoverPosition(target, alignment);
+    setPopoverPosition(position);
+  };
+
+  useEffect(() => {
+    if (!showsPopover) return;
+
+    function handleWindowResize() {
+      updatePopoverPosition(target, alignment);
+    }
+
+    window.addEventListener("resize", handleWindowResize);
+    return () => window.removeEventListener("resize", handleWindowResize);
+  }, [showsPopover, target, alignment]);
 
   return {
     popoverPosition,

--- a/src/hooks/use-popover.jsx
+++ b/src/hooks/use-popover.jsx
@@ -1,0 +1,49 @@
+import { useContext, useState } from "react";
+import POPOVER_ALIGNMENT from "../components/popover/popover-alignment";
+import PopoverContext from "../components/popover/popover-context";
+
+function calculatePopoverPosition(target, alignment) {
+  if (!target) {
+    return { top: 0, left: 0, right: 0 };
+  }
+
+  const targetRect = target.getBoundingClientRect();
+  const position = {
+    top: targetRect.bottom + 8,
+  };
+
+  switch (alignment) {
+    case POPOVER_ALIGNMENT.right:
+      position.right = window.innerWidth - targetRect.right;
+      break;
+    default:
+      position.left = targetRect.left;
+      break;
+  }
+
+  return position;
+}
+
+function usePopover() {
+  const { showsPopover, setShowsPopover } = useContext(PopoverContext);
+  const [popoverPosition, setPopoverPosition] = useState();
+
+  const openPopopver = ({ target, alignment }) => {
+    const position = calculatePopoverPosition(target, alignment);
+    setShowsPopover(true);
+    setPopoverPosition(position);
+  };
+
+  const closePopover = () => {
+    setShowsPopover(false);
+  };
+
+  return {
+    popoverPosition,
+    showsPopover,
+    openPopopver,
+    closePopover,
+  };
+}
+
+export { usePopover };

--- a/src/pages/test-page.jsx
+++ b/src/pages/test-page.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import styled from "styled-components";
 import smileAddImg from "../assets/ic-face-smile-add.svg";
 import Badge from "../components/badge/badge";
@@ -15,10 +15,13 @@ import BUTTON_SIZE from "../components/button/button-size";
 import ToggleButton from "../components/button/toggle-button";
 import Header from "../components/header/header";
 import Modal from "../components/modal/modal";
+import Popover from "../components/popover/popover";
+import POPOVER_ALIGNMENT from "../components/popover/popover-alignment";
 import TextField from "../components/text-field/text-field";
 import TEXT_FIELD_TYPE from "../components/text-field/text-field-type";
 import Toast from "../components/toast/toast";
 import { useModal } from "../hooks/use-modal";
+import { usePopover } from "../hooks/use-popover";
 import { useToast } from "../hooks/use-toast";
 
 const OutlinedHeader = styled(Header)`
@@ -44,11 +47,30 @@ function TestPage() {
 
   const handleToastClick = () => setShowsToast(true);
   const handleToastDismiss = () => setShowsToast(false);
-  
+
   /* Modal */
   const { showsModal, setShowsModal } = useModal();
   const handleModalClick = () => setShowsModal(true);
-  
+
+  /* Popover */
+  const { popoverPosition, showsPopover, openPopopver, closePopover } =
+    usePopover();
+  const popoverLeftRef = useRef();
+  const popoverRightRef = useRef();
+
+  const handlePopoverLeftClick = () => {
+    openPopopver({
+      target: popoverLeftRef.current,
+      alignment: POPOVER_ALIGNMENT.left,
+    });
+  };
+  const handlePopoverRightClick = () => {
+    openPopopver({
+      target: popoverRightRef.current,
+      alignment: POPOVER_ALIGNMENT.right,
+    });
+  };
+
   return (
     <div
       style={{
@@ -207,6 +229,27 @@ function TestPage() {
             content="코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력 모두 조심 또 하세요! 코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력 모두 조심 또 하세요!코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력 모두 조심 또 하세요!코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력 모두 조심 또 하세요!코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력 모두 조심 또 하세요!코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력 모두 조심 또 하세요! 코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력 모두 조심 또 하세요!코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력 모두 조심 또 하세요!코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력 모두 조심 또 하세요!코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력 모두 조심 또 하세요!코로나가 또다시 기승을 부리는 요즘이네요. 건강, 체력 모두 조심 또 하세요!"
           />
         )}
+      </div>
+      <div style={{ display: "flex", gap: "16px" }}>
+        <PrimaryButton
+          size={BUTTON_SIZE.small}
+          title="Show Popover on Left"
+          onClick={handlePopoverLeftClick}
+          ref={popoverLeftRef}
+        />
+        <PrimaryButton
+          size={BUTTON_SIZE.small}
+          title="Show Popover on Right"
+          onClick={handlePopoverRightClick}
+          ref={popoverRightRef}
+        />
+        <Popover
+          isOpen={showsPopover}
+          onClose={closePopover}
+          position={popoverPosition}
+        >
+          <h1>This is Popover.</h1>
+        </Popover>
       </div>
     </div>
   );


### PR DESCRIPTION
## 📝 작업 내용

- Popover UI를 만들 수 있는 `Popover` 공통 component를 구현합니다.
- Dropdown, Modal과 사용법이 약간 다릅니다. 
  - Dropdown, Modal과 달리, `Popover`는 `isOpen` prop을 통해서 render 여부를 결정합니다.
  - 실제로 개발할 때 사용해 보고, 더 나은 방법으로 변경할 예정입니다.
- `<Popover>` component의 하위에 popover로 보여주고 싶은 component를 넣는 방식으로 사용합니다.
- `Popover` component 자체는 padding을 갖고 있지 않으므로, 내부에 보여주려는 component가 자체적으로 margin 또는 padding을 가져야 합니다.

## 📷 스크린샷 (선택)

| 왼쪽 끝에 정렬 | 오른쪽 끝에 정렬 |
|--------|--------|
| <img width="462" height="147" alt="image" src="https://github.com/user-attachments/assets/dd59f095-1d07-4c9e-9bdb-3f80aef7d7e2" /> | <img width="462" height="147" alt="image" src="https://github.com/user-attachments/assets/d23e3633-fdcf-4372-b6c3-c3e3babc997e" /> |
