### PR TITLE
[#43] [#43] rolling paper list 페이지, 내부 컴포넌트 분리 및 데이터 정렬

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -5,7 +5,7 @@ import ContentLayout from "./layouts/content-layout";
 import OnboardingLayout from "./layouts/onboarding-layout";
 import CreatePostPage from "./pages/create-post-page";
 import MainPage from "./pages/main-page";
-import MessagePage from "./pages/message-list";
+import MessagePage from "./pages/rolling-paper-list-page";
 import RecipientPostPage from "./pages/recipient-post-page";
 import SendMessagePage from "./pages/send-message-page";
 import TestPage from "./pages/test-page";

--- a/src/features/rolling-paper/components/rolling-paper-list.jsx
+++ b/src/features/rolling-paper/components/rolling-paper-list.jsx
@@ -1,0 +1,144 @@
+import ArrowButton from "../../../components/button/arrow-button";
+import ARROW_BUTTON_DIRECTION from "../../../components/button/arrow-button-direction";
+import {
+  OutlinedButton,
+  PrimaryButton,
+  SecondaryButton,
+} from "../../../components/button/button";
+import BUTTON_SIZE from "../../../components/button/button-size";
+import ToggleButton from "../../../components/button/toggle-button";
+
+import React, { useEffect, useState } from "react";
+
+import styled from "styled-components";
+
+const backgroundColors = {
+  beige: "#FFD382",
+  purple: "#DCB9FF",
+  green: "#9BE282",
+  blue: "#9DDDFF",
+};
+
+const CardContainer = styled.div`
+  display: grid;
+  grid-template-columns: 275px 275px 275px 275px;
+  gap: 20px;
+  width: fit-content;
+
+  position: relative;
+  overflow: visible;
+`;
+
+const CardItem = styled.div.withConfig({
+  shouldForwardProp: (prop) => prop !== "backgroundColor",
+})`
+  width: 275px;
+  height: 260px;
+  border-radius: 16px;
+  text-align: left;
+  padding: 30px 24px 20px 24px;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+
+  display: grid;
+  grid-template-rows: 1fr 1fr auto;
+
+  background-color: ${(props) =>
+    backgroundColors[props.backgroundColor] || "white"};
+
+  img {
+    height: 28px;
+    width: 28px;
+    border-radius: 50%;
+    border: 1px solid #ffffff;
+
+    margin-left: -12px;
+    &:first-child {
+      margin-left: 0;
+    }
+  }
+
+  div.message-images {
+    display: flex;
+  }
+
+  div.over-profile {
+    height: 28px;
+    width: 28px;
+    background-color: #ffffff;
+    border-radius: 50%;
+
+    margin-left: -12px;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 12px;
+  }
+
+  h2 {
+    margin: 0;
+  }
+
+  div.emoji-div {
+    border-top: 1px solid red;
+  }
+`;
+
+const NextButtonWrapper = styled.div`
+  position: absolute;
+  right: -20px;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 10;
+`;
+
+const PreviewButtonWrapper = styled.div`
+  position: absolute;
+  left: -20px;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 10;
+`;
+
+function RollingPaperList({ cardData, totalPages, currentPage, onTurnCards }) {
+  return (
+    <CardContainer>
+      {cardData.map((item) => (
+        <CardItem key={item.id} backgroundColor={item.backgroundColor}>
+          <h2>To. {item.name}</h2>
+          <div className="message-images">
+            {item.recentMessages.slice(0, 3).map((messageItem, index) => (
+              <img
+                key={index}
+                src={messageItem.profileImageURL}
+                alt={`profile-${index}`}
+                loading="lazy"
+              />
+            ))}
+            {item.messageCount > 3 ? (
+              <div className="over-profile">
+                <span>+{item.messageCount - 3}</span>
+              </div>
+            ) : null}
+          </div>
+          <span>
+            <strong>{item.messageCount}</strong>명이 작성했어요!
+          </span>
+          <div className="emoji-div">test</div>
+        </CardItem>
+      ))}
+      {currentPage > 0 ? (
+        <PreviewButtonWrapper onClick={() => onTurnCards("preview")}>
+          <ArrowButton direction={ARROW_BUTTON_DIRECTION.left} />
+        </PreviewButtonWrapper>
+      ) : null}
+      {currentPage < totalPages - 1 ? (
+        <NextButtonWrapper onClick={() => onTurnCards("next")}>
+          <ArrowButton direction={ARROW_BUTTON_DIRECTION.right} />
+        </NextButtonWrapper>
+      ) : null}
+    </CardContainer>
+  );
+}
+
+export default RollingPaperList;

--- a/src/pages/message-list.jsx
+++ b/src/pages/message-list.jsx
@@ -10,128 +10,174 @@ import ToggleButton from "../components/button/toggle-button";
 
 import React, { useEffect, useState } from "react";
 import axiosInstance from "../api/axios-instance";
+import styled from "styled-components";
+
+/* styled components */
+const TopContainer = styled.div`
+  text-align: center;
+`;
+
+const CardSection = styled.section`
+  justify-self: center;
+`;
+
+const CardTitle = styled.h2`
+  text-align: left;
+`;
+
+const CardContainer = styled.div`
+  border: 1px solid red;
+  display: grid;
+  grid-template-columns: 275px 275px 275px 275px;
+  gap: 20px;
+  width: fit-content;
+
+  position: relative;
+  overflow: visible;
+`;
+
+const CardItem = styled.div`
+  width: 275px;
+  height: 260px;
+  border: 1px solid red;
+`;
+
+const NextBtnWpr = styled.div`
+  position: absolute;
+  right: -20px;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 10;
+`;
+
+const PrevBtnWpr = styled.div`
+  position: absolute;
+  left: -20px;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 10;
+`;
+
+const MakingBtn = styled(PrimaryButton)`
+  margin-top: 64px;
+  font-weight: 400;
+  padding: 14px 60px;
+`;
+
+/* 그냥 출력 테스트용 */
+const testData = [
+  { id: 1, to: "test1", messageCount: 1 },
+  { id: 2, to: "test2", messageCount: 5 },
+  { id: 3, to: "test3", messageCount: 10 },
+  { id: 4, to: "test4", messageCount: 2 },
+  { id: 5, to: "test5", messageCount: 3 },
+  { id: 6, to: "test6", messageCount: 1 },
+];
 
 function ShowMessageList() {
-  // const [imageUrl, setImageUrl] = useState(null);
+  const [pprCurrentPage, setPprCurrentPage] = useState(0); // 인기카드
+  const [currentPage, setCurrentPage] = useState(0); // 일반카드
+  const [pprShowCards, setPprShowCards] = useState([]);
+  const [showCards, setShowCards] = useState([]);
+  const cardCount = 4;
 
-  const cardConStyle = {
-    border: "1px solid red",
-    display: "grid",
-    gridTemplateColumns: "275px 275px 275px 275px",
-    gap: "20px",
-    width: "fit-content",
+  /* axios로 데이터 가져온다고 가정 */
+  // axiosInstance
+  //   .get("/18-3/recipients/?limit=5&offset=20")
+  //   .then((res) => {
+  //     console.log(res.data);
+  //   })
+  //   .catch(console.error);
 
-    position: "relative",
-    overflow: "visible",
-  };
-
-  const cardStyle = {
-    width: "275px",
-    height: "260px",
-    border: "1px solid red",
-  };
-
-  const testStyle = {
-    textAlign: "center",
-  };
-
-  const sectionStyle = {
-    justifySelf: "center",
-  };
-
-  const buttonStyle = {
-    marginTop: "64px",
-    fontWeight: "400",
-    padding: "14px 60px",
-  };
-
-  const htStyle = {
-    textAlign: "left",
-  };
-
-  const rButton = {
-    position: "absolute",
-    right: -20, // 필요시 조정
-    top: "50%",
-    transform: "translateY(-50%)",
-    zIndex: 20,
-  };
-
-  const lButton = {
-    position: "absolute",
-    left: -20, // 필요시 조정
-    top: "50%",
-    transform: "translateY(-50%)",
-    zIndex: 20,
-  };
+  const totalPages = Math.ceil(testData.length / cardCount);
 
   useEffect(() => {
-    axiosInstance
-      .get("/18-3/recipients/?limit=5&offset=20")
-      .then((res) => {
-        console.log(res.data);
-      })
-      .catch(console.error);
-  }, []);
+    const strtPageNum = currentPage * cardCount;
+    const endPageNum = strtPageNum + cardCount;
+
+    const pprStrtPageNum = pprCurrentPage * cardCount;
+    const pprEndPageNum = pprStrtPageNum + cardCount;
+
+    /* createdAt(생성된 시점)에 따라서 정렬 */
+    setShowCards(testData.slice(strtPageNum, endPageNum));
+
+    /* 여기서 messageCount(메시지수)에 따라서 정렬 */
+    setPprShowCards(testData.slice(pprStrtPageNum, pprEndPageNum));
+  }, [pprCurrentPage, currentPage]);
+
+  const nextPage = (mode = null) => {
+    if (mode) {
+      console.log("pprnext");
+      if (pprCurrentPage < totalPages - 1) {
+        setPprCurrentPage((pprCurrentNum) => pprCurrentNum + 1);
+      }
+    } else {
+      console.log("justnext");
+      if (currentPage < totalPages - 1) {
+        setCurrentPage((currentNum) => currentNum + 1);
+      }
+    }
+  };
+
+  const prevPage = (mode = null) => {
+    if (mode) {
+      console.log("pprprev");
+      if (pprCurrentPage > 0) {
+        setPprCurrentPage((pprCurrentNum) => pprCurrentNum - 1);
+      }
+    } else {
+      console.log("justprev");
+      if (currentPage > 0) {
+        setCurrentPage((currentNum) => currentNum - 1);
+      }
+    }
+  };
 
   return (
-    <div style={testStyle}>
+    <TopContainer>
       /* navi 들어갈 자리 */
       <article>
-        <section style={sectionStyle}>
-          <h2 style={htStyle}>인기 롤링 페이퍼 🔥</h2>
-          <div className="card-container" style={cardConStyle}>
-            <div className="card" style={cardStyle}></div>
-            <div className="card" style={cardStyle}></div>
-            <div className="card" style={cardStyle}></div>
-            <div className="card" style={cardStyle}></div>
-            <div style={rButton}>
-              <ArrowButton direction={ARROW_BUTTON_DIRECTION.right} />
-            </div>
-          </div>
-        </section>
-        <section style={sectionStyle}>
-          <h2 style={htStyle}>최근에 만든 롤링 페이퍼 ⭐</h2>
-          <div className="card-container" style={cardConStyle}>
-            <div className="card" style={cardStyle}></div>
-            <div className="card" style={cardStyle}></div>
-            <div className="card" style={cardStyle}></div>
-            <div className="card" style={cardStyle}></div>
-            <div style={lButton}>
-              <ArrowButton direction={ARROW_BUTTON_DIRECTION.left} />
-            </div>
-          </div>
-        </section>
+        <CardSection>
+          <CardTitle>인기 롤링 페이퍼 🔥</CardTitle>
+          <CardContainer>
+            {pprShowCards.map((item) => (
+              <CardItem key={item.id}>{item.to}</CardItem> // 테스트용
+            ))}
+            {pprCurrentPage > 0 ? (
+              <PrevBtnWpr onClick={() => prevPage("ppr")}>
+                <ArrowButton direction={ARROW_BUTTON_DIRECTION.left} />
+              </PrevBtnWpr>
+            ) : null}
+            {pprCurrentPage < totalPages - 1 ? (
+              <NextBtnWpr onClick={() => nextPage("ppr")}>
+                <ArrowButton direction={ARROW_BUTTON_DIRECTION.right} />
+              </NextBtnWpr>
+            ) : null}
+          </CardContainer>
+        </CardSection>
+
+        <CardSection>
+          <CardTitle>최근에 만든 롤링 페이퍼 ⭐</CardTitle>
+          <CardContainer>
+            {showCards.map((item) => (
+              <CardItem key={item.id}>{item.to}</CardItem> // 테스트용
+            ))}
+            {currentPage > 0 ? (
+              <PrevBtnWpr onClick={() => prevPage()}>
+                <ArrowButton direction={ARROW_BUTTON_DIRECTION.left} />
+              </PrevBtnWpr>
+            ) : null}
+            {currentPage < totalPages - 1 ? (
+              <NextBtnWpr onClick={() => nextPage()}>
+                <ArrowButton direction={ARROW_BUTTON_DIRECTION.right} />
+              </NextBtnWpr>
+            ) : null}
+          </CardContainer>
+        </CardSection>
       </article>
-      <PrimaryButton
-        size={BUTTON_SIZE.large}
-        style={buttonStyle}
-        title="나도 만들어보기"
-      />
-    </div>
+      <MakingBtn size={BUTTON_SIZE.large} title="나도 만들어보기" />
+    </TopContainer>
   );
-
-  /* axios 사용 예시코드 */
-  // useEffect(() => {
-  //   axiosInstance
-  //     .get("/background-images/")
-  //     .then((res) => {
-  //       if (res.data && res.data.imageUrls && res.data.imageUrls.length > 0) {
-  //         setImageUrl(res.data.imageUrls[0]);
-  //       }
-  //     })
-  //     .catch(console.error);
-  // }, []);
-
-  // return (
-  //   <div>
-  //     {imageUrl ? (
-  //       <img src={imageUrl} alt="background" style={{ maxWidth: "100%" }} />
-  //     ) : (
-  //       <p>이미지를 불러오는 중입니다...</p>
-  //     )}
-  //   </div>
-  // );
 }
 
 export default ShowMessageList;

--- a/src/pages/message-list.jsx
+++ b/src/pages/message-list.jsx
@@ -10,174 +10,128 @@ import ToggleButton from "../components/button/toggle-button";
 
 import React, { useEffect, useState } from "react";
 import axiosInstance from "../api/axios-instance";
-import styled from "styled-components";
-
-/* styled components */
-const TopContainer = styled.div`
-  text-align: center;
-`;
-
-const CardSection = styled.section`
-  justify-self: center;
-`;
-
-const CardTitle = styled.h2`
-  text-align: left;
-`;
-
-const CardContainer = styled.div`
-  border: 1px solid red;
-  display: grid;
-  grid-template-columns: 275px 275px 275px 275px;
-  gap: 20px;
-  width: fit-content;
-
-  position: relative;
-  overflow: visible;
-`;
-
-const CardItem = styled.div`
-  width: 275px;
-  height: 260px;
-  border: 1px solid red;
-`;
-
-const NextBtnWpr = styled.div`
-  position: absolute;
-  right: -20px;
-  top: 50%;
-  transform: translateY(-50%);
-  z-index: 10;
-`;
-
-const PrevBtnWpr = styled.div`
-  position: absolute;
-  left: -20px;
-  top: 50%;
-  transform: translateY(-50%);
-  z-index: 10;
-`;
-
-const MakingBtn = styled(PrimaryButton)`
-  margin-top: 64px;
-  font-weight: 400;
-  padding: 14px 60px;
-`;
-
-/* 그냥 출력 테스트용 */
-const testData = [
-  { id: 1, to: "test1", messageCount: 1 },
-  { id: 2, to: "test2", messageCount: 5 },
-  { id: 3, to: "test3", messageCount: 10 },
-  { id: 4, to: "test4", messageCount: 2 },
-  { id: 5, to: "test5", messageCount: 3 },
-  { id: 6, to: "test6", messageCount: 1 },
-];
 
 function ShowMessageList() {
-  const [pprCurrentPage, setPprCurrentPage] = useState(0); // 인기카드
-  const [currentPage, setCurrentPage] = useState(0); // 일반카드
-  const [pprShowCards, setPprShowCards] = useState([]);
-  const [showCards, setShowCards] = useState([]);
-  const cardCount = 4;
+  // const [imageUrl, setImageUrl] = useState(null);
 
-  /* axios로 데이터 가져온다고 가정 */
-  // axiosInstance
-  //   .get("/18-3/recipients/?limit=5&offset=20")
-  //   .then((res) => {
-  //     console.log(res.data);
-  //   })
-  //   .catch(console.error);
+  const cardConStyle = {
+    border: "1px solid red",
+    display: "grid",
+    gridTemplateColumns: "275px 275px 275px 275px",
+    gap: "20px",
+    width: "fit-content",
 
-  const totalPages = Math.ceil(testData.length / cardCount);
+    position: "relative",
+    overflow: "visible",
+  };
+
+  const cardStyle = {
+    width: "275px",
+    height: "260px",
+    border: "1px solid red",
+  };
+
+  const testStyle = {
+    textAlign: "center",
+  };
+
+  const sectionStyle = {
+    justifySelf: "center",
+  };
+
+  const buttonStyle = {
+    marginTop: "64px",
+    fontWeight: "400",
+    padding: "14px 60px",
+  };
+
+  const htStyle = {
+    textAlign: "left",
+  };
+
+  const rButton = {
+    position: "absolute",
+    right: -20, // 필요시 조정
+    top: "50%",
+    transform: "translateY(-50%)",
+    zIndex: 20,
+  };
+
+  const lButton = {
+    position: "absolute",
+    left: -20, // 필요시 조정
+    top: "50%",
+    transform: "translateY(-50%)",
+    zIndex: 20,
+  };
 
   useEffect(() => {
-    const strtPageNum = currentPage * cardCount;
-    const endPageNum = strtPageNum + cardCount;
-
-    const pprStrtPageNum = pprCurrentPage * cardCount;
-    const pprEndPageNum = pprStrtPageNum + cardCount;
-
-    /* createdAt(생성된 시점)에 따라서 정렬 */
-    setShowCards(testData.slice(strtPageNum, endPageNum));
-
-    /* 여기서 messageCount(메시지수)에 따라서 정렬 */
-    setPprShowCards(testData.slice(pprStrtPageNum, pprEndPageNum));
-  }, [pprCurrentPage, currentPage]);
-
-  const nextPage = (mode = null) => {
-    if (mode) {
-      console.log("pprnext");
-      if (pprCurrentPage < totalPages - 1) {
-        setPprCurrentPage((pprCurrentNum) => pprCurrentNum + 1);
-      }
-    } else {
-      console.log("justnext");
-      if (currentPage < totalPages - 1) {
-        setCurrentPage((currentNum) => currentNum + 1);
-      }
-    }
-  };
-
-  const prevPage = (mode = null) => {
-    if (mode) {
-      console.log("pprprev");
-      if (pprCurrentPage > 0) {
-        setPprCurrentPage((pprCurrentNum) => pprCurrentNum - 1);
-      }
-    } else {
-      console.log("justprev");
-      if (currentPage > 0) {
-        setCurrentPage((currentNum) => currentNum - 1);
-      }
-    }
-  };
+    axiosInstance
+      .get("/18-3/recipients/?limit=5&offset=20")
+      .then((res) => {
+        console.log(res.data);
+      })
+      .catch(console.error);
+  }, []);
 
   return (
-    <TopContainer>
+    <div style={testStyle}>
       /* navi 들어갈 자리 */
       <article>
-        <CardSection>
-          <CardTitle>인기 롤링 페이퍼 🔥</CardTitle>
-          <CardContainer>
-            {pprShowCards.map((item) => (
-              <CardItem key={item.id}>{item.to}</CardItem> // 테스트용
-            ))}
-            {pprCurrentPage > 0 ? (
-              <PrevBtnWpr onClick={() => prevPage("ppr")}>
-                <ArrowButton direction={ARROW_BUTTON_DIRECTION.left} />
-              </PrevBtnWpr>
-            ) : null}
-            {pprCurrentPage < totalPages - 1 ? (
-              <NextBtnWpr onClick={() => nextPage("ppr")}>
-                <ArrowButton direction={ARROW_BUTTON_DIRECTION.right} />
-              </NextBtnWpr>
-            ) : null}
-          </CardContainer>
-        </CardSection>
-
-        <CardSection>
-          <CardTitle>최근에 만든 롤링 페이퍼 ⭐</CardTitle>
-          <CardContainer>
-            {showCards.map((item) => (
-              <CardItem key={item.id}>{item.to}</CardItem> // 테스트용
-            ))}
-            {currentPage > 0 ? (
-              <PrevBtnWpr onClick={() => prevPage()}>
-                <ArrowButton direction={ARROW_BUTTON_DIRECTION.left} />
-              </PrevBtnWpr>
-            ) : null}
-            {currentPage < totalPages - 1 ? (
-              <NextBtnWpr onClick={() => nextPage()}>
-                <ArrowButton direction={ARROW_BUTTON_DIRECTION.right} />
-              </NextBtnWpr>
-            ) : null}
-          </CardContainer>
-        </CardSection>
+        <section style={sectionStyle}>
+          <h2 style={htStyle}>인기 롤링 페이퍼 🔥</h2>
+          <div className="card-container" style={cardConStyle}>
+            <div className="card" style={cardStyle}></div>
+            <div className="card" style={cardStyle}></div>
+            <div className="card" style={cardStyle}></div>
+            <div className="card" style={cardStyle}></div>
+            <div style={rButton}>
+              <ArrowButton direction={ARROW_BUTTON_DIRECTION.right} />
+            </div>
+          </div>
+        </section>
+        <section style={sectionStyle}>
+          <h2 style={htStyle}>최근에 만든 롤링 페이퍼 ⭐</h2>
+          <div className="card-container" style={cardConStyle}>
+            <div className="card" style={cardStyle}></div>
+            <div className="card" style={cardStyle}></div>
+            <div className="card" style={cardStyle}></div>
+            <div className="card" style={cardStyle}></div>
+            <div style={lButton}>
+              <ArrowButton direction={ARROW_BUTTON_DIRECTION.left} />
+            </div>
+          </div>
+        </section>
       </article>
-      <MakingBtn size={BUTTON_SIZE.large} title="나도 만들어보기" />
-    </TopContainer>
+      <PrimaryButton
+        size={BUTTON_SIZE.large}
+        style={buttonStyle}
+        title="나도 만들어보기"
+      />
+    </div>
   );
+
+  /* axios 사용 예시코드 */
+  // useEffect(() => {
+  //   axiosInstance
+  //     .get("/background-images/")
+  //     .then((res) => {
+  //       if (res.data && res.data.imageUrls && res.data.imageUrls.length > 0) {
+  //         setImageUrl(res.data.imageUrls[0]);
+  //       }
+  //     })
+  //     .catch(console.error);
+  // }, []);
+
+  // return (
+  //   <div>
+  //     {imageUrl ? (
+  //       <img src={imageUrl} alt="background" style={{ maxWidth: "100%" }} />
+  //     ) : (
+  //       <p>이미지를 불러오는 중입니다...</p>
+  //     )}
+  //   </div>
+  // );
 }
 
 export default ShowMessageList;

--- a/src/pages/rolling-paper-list-page.jsx
+++ b/src/pages/rolling-paper-list-page.jsx
@@ -13,13 +13,7 @@ import axiosInstance from "../api/axios-instance";
 import testDataFile from "./test_recipients_data.json";
 
 import styled from "styled-components";
-
-const backgroundColors = {
-  beige: "#FFD382",
-  purple: "#DCB9FF",
-  green: "#9BE282",
-  blue: "#9DDDFF",
-};
+import RollingPaperList from "../features/rolling-paper/components/rolling-paper-list";
 
 const TopContainer = styled.div`
   text-align: center;
@@ -33,93 +27,25 @@ const CardTitle = styled.h2`
   text-align: left;
 `;
 
-const CardContainer = styled.div`
-  border: 1px solid red;
-  display: grid;
-  grid-template-columns: 275px 275px 275px 275px;
-  gap: 20px;
-  width: fit-content;
-
-  position: relative;
-  overflow: visible;
-`;
-
-const CardItem = styled.div`
-  width: 275px;
-  height: 260px;
-  border: 1px solid red;
-  text-align: left;
-  padding: 30px 24px 20px 24px;
-
-  display: grid;
-  grid-template-rows: 1fr 1fr auto;
-
-  background-color: ${(props) =>
-    backgroundColors[props.backgroundColor] || "white"};
-
-  img {
-    height: 28px;
-    width: 28px;
-    border-radius: 50%;
-    border: 1px solid #ffffff;
-
-    margin-left: -12px;
-    &:first-child {
-      margin-left: 0;
-    }
-  }
-
-  div.message-images {
-    display: flex;
-  }
-
-  div.over-profile {
-    height: 28px;
-    width: 28px;
-    background-color: #ffffff;
-    border-radius: 50%;
-
-    margin-left: -12px;
-
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    font-size: 12px;
-  }
-
-  h2 {
-    margin: 0;
-  }
-
-  div.emoji-div {
-    border-top: 1px solid red;
-  }
-`;
-
-const NextButtonWrapper = styled.div`
-  position: absolute;
-  right: -20px;
-  top: 50%;
-  transform: translateY(-50%);
-  z-index: 10;
-`;
-
-const PreviewButtonWrapper = styled.div`
-  position: absolute;
-  left: -20px;
-  top: 50%;
-  transform: translateY(-50%);
-  z-index: 10;
-`;
-
 const MakingButton = styled(PrimaryButton)`
   margin-top: 64px;
   font-weight: 400;
   padding: 14px 60px;
 `;
 
+const cache = {};
+function getCachedImage(url) {
+  if (!cache[url]) {
+    cache[url] = new Image();
+    cache[url].src = url;
+  }
+  return cache[url].src;
+}
+
 function ShowMessageList() {
   const [testData, setTestData] = useState([]);
+  const [popularDataList, setPopularDataList] = useState([]);
+  const [recentDataList, setRecentDataList] = useState([]);
   const [popularCurrentPage, setPopularCurrentPage] = useState(0);
   const [recentCurrentPage, setRecentCurrentPage] = useState(0);
   const [popularrecentShowCards, setPopularrecentShowCards] = useState([]);
@@ -139,6 +65,24 @@ function ShowMessageList() {
     //   });
   }, []);
 
+  useEffect(() => {
+    testData.forEach((item) => {
+      getCachedImage(item.imageURL);
+    });
+  }, [testData]);
+
+  useEffect(() => {
+    const sortedPopular = testData
+      .slice()
+      .sort((a, b) => b.messageCount - a.messageCount);
+    setPopularDataList(sortedPopular);
+
+    const sortedRecent = testData
+      .slice()
+      .sort((a, b) => b.createdAt - a.createdAt);
+    setRecentDataList(sortedRecent);
+  }, [testData]);
+
   const totalPages = Math.ceil(testData.length / cardCount);
 
   useEffect(() => {
@@ -148,14 +92,17 @@ function ShowMessageList() {
     const popularStartPageNum = popularCurrentPage * cardCount;
     const popularEndPageNum = popularStartPageNum + cardCount;
 
-    /* createdAt(생성된 시점)에 따라서 정렬 */
-    setRecentShowCards(testData.slice(startPageNum, endPageNum));
-
-    /* 여기서 messageCount(메시지수)에 따라서 정렬 */
     setPopularrecentShowCards(
-      testData.slice(popularStartPageNum, popularEndPageNum)
+      popularDataList.slice(popularStartPageNum, popularEndPageNum)
     );
-  }, [popularCurrentPage, recentCurrentPage, testData]);
+    setRecentShowCards(recentDataList.slice(startPageNum, endPageNum));
+  }, [
+    popularCurrentPage,
+    recentCurrentPage,
+    testData,
+    popularDataList,
+    recentDataList,
+  ]);
 
   const handleTurnCards = (direction, mode) => {
     const current = mode === "popular" ? popularCurrentPage : recentCurrentPage;
@@ -176,89 +123,22 @@ function ShowMessageList() {
       <article>
         <CardSection>
           <CardTitle>인기 롤링 페이퍼 🔥</CardTitle>
-          <CardContainer>
-            {popularrecentShowCards.map((item) => (
-              <CardItem key={item.id} backgroundColor={item.backgroundColor}>
-                <h2>To. {item.name}</h2>
-                <div className="message-images">
-                  {item.recentMessages.slice(0, 3).map((messageItem, index) => (
-                    <img
-                      key={index}
-                      src={messageItem.profileImageURL}
-                      alt={`profile-${index}`}
-                      loading="lazy"
-                    />
-                  ))}
-                  {item.messageCount > 3 ? (
-                    <div className="over-profile">
-                      <span>+{item.messageCount - 3}</span>
-                    </div>
-                  ) : null}
-                </div>
-                <span>
-                  <strong>{item.messageCount}</strong>명이 작성했어요!
-                </span>
-                <div className="emoji-div">test</div>
-              </CardItem>
-            ))}
-            {popularCurrentPage > 0 ? (
-              <PreviewButtonWrapper
-                onClick={() => handleTurnCards("preview", "popular")}
-              >
-                <ArrowButton direction={ARROW_BUTTON_DIRECTION.left} />
-              </PreviewButtonWrapper>
-            ) : null}
-            {popularCurrentPage < totalPages - 1 ? (
-              <NextButtonWrapper
-                onClick={() => handleTurnCards("next", "popular")}
-              >
-                <ArrowButton direction={ARROW_BUTTON_DIRECTION.right} />
-              </NextButtonWrapper>
-            ) : null}
-          </CardContainer>
+          <RollingPaperList
+            cardData={popularrecentShowCards}
+            totalPages={totalPages}
+            currentPage={popularCurrentPage}
+            onTurnCards={(direction) => handleTurnCards(direction, "popular")}
+          />
         </CardSection>
 
         <CardSection>
           <CardTitle>최근에 만든 롤링 페이퍼 ⭐</CardTitle>
-          <CardContainer>
-            {recentShowCards.map((item) => (
-              <CardItem key={item.id} backgroundColor={item.backgroundColor}>
-                <h2>To. {item.name}</h2>
-                <div className="message-images">
-                  {item.recentMessages.slice(0, 3).map((messageItem, index) => (
-                    <img
-                      key={index}
-                      src={messageItem.profileImageURL}
-                      alt={`profile-${index}`}
-                      loading="lazy"
-                    />
-                  ))}
-                  {item.messageCount > 3 ? (
-                    <div className="over-profile">
-                      <span>+{item.messageCount - 3}</span>
-                    </div>
-                  ) : null}
-                </div>
-                <span>
-                  <strong>{item.messageCount}</strong>명이 작성했어요!
-                </span>
-              </CardItem>
-            ))}
-            {recentCurrentPage > 0 ? (
-              <PreviewButtonWrapper
-                onClick={() => handleTurnCards("preview", "recent")}
-              >
-                <ArrowButton direction={ARROW_BUTTON_DIRECTION.left} />
-              </PreviewButtonWrapper>
-            ) : null}
-            {recentCurrentPage < totalPages - 1 ? (
-              <NextButtonWrapper
-                onClick={() => handleTurnCards("next", "recent")}
-              >
-                <ArrowButton direction={ARROW_BUTTON_DIRECTION.right} />
-              </NextButtonWrapper>
-            ) : null}
-          </CardContainer>
+          <RollingPaperList
+            cardData={recentShowCards}
+            totalPages={totalPages}
+            currentPage={recentCurrentPage}
+            onTurnCards={(direction) => handleTurnCards(direction, "recent")}
+          />
         </CardSection>
       </article>
       <MakingButton size={BUTTON_SIZE.large} title="나도 만들어보기" />

--- a/src/pages/rolling-paper-list-page.jsx
+++ b/src/pages/rolling-paper-list-page.jsx
@@ -1,0 +1,271 @@
+import ArrowButton from "../components/button/arrow-button";
+import ARROW_BUTTON_DIRECTION from "../components/button/arrow-button-direction";
+import {
+  OutlinedButton,
+  PrimaryButton,
+  SecondaryButton,
+} from "../components/button/button";
+import BUTTON_SIZE from "../components/button/button-size";
+import ToggleButton from "../components/button/toggle-button";
+
+import React, { useEffect, useState } from "react";
+import axiosInstance from "../api/axios-instance";
+import testDataFile from "./test_recipients_data.json";
+
+import styled from "styled-components";
+
+const backgroundColors = {
+  beige: "#FFD382",
+  purple: "#DCB9FF",
+  green: "#9BE282",
+  blue: "#9DDDFF",
+};
+
+const TopContainer = styled.div`
+  text-align: center;
+`;
+
+const CardSection = styled.section`
+  justify-self: center;
+`;
+
+const CardTitle = styled.h2`
+  text-align: left;
+`;
+
+const CardContainer = styled.div`
+  border: 1px solid red;
+  display: grid;
+  grid-template-columns: 275px 275px 275px 275px;
+  gap: 20px;
+  width: fit-content;
+
+  position: relative;
+  overflow: visible;
+`;
+
+const CardItem = styled.div`
+  width: 275px;
+  height: 260px;
+  border: 1px solid red;
+  text-align: left;
+  padding: 30px 24px 20px 24px;
+
+  display: grid;
+  grid-template-rows: 1fr 1fr auto;
+
+  background-color: ${(props) =>
+    backgroundColors[props.backgroundColor] || "white"};
+
+  img {
+    height: 28px;
+    width: 28px;
+    border-radius: 50%;
+    border: 1px solid #ffffff;
+
+    margin-left: -12px;
+    &:first-child {
+      margin-left: 0;
+    }
+  }
+
+  div.message-images {
+    display: flex;
+  }
+
+  div.over-profile {
+    height: 28px;
+    width: 28px;
+    background-color: #ffffff;
+    border-radius: 50%;
+
+    margin-left: -12px;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 12px;
+  }
+
+  h2 {
+    margin: 0;
+  }
+
+  div.emoji-div {
+    border-top: 1px solid red;
+  }
+`;
+
+const NextBtnWpr = styled.div`
+  position: absolute;
+  right: -20px;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 10;
+`;
+
+const PrevBtnWpr = styled.div`
+  position: absolute;
+  left: -20px;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 10;
+`;
+
+const MakingBtn = styled(PrimaryButton)`
+  margin-top: 64px;
+  font-weight: 400;
+  padding: 14px 60px;
+`;
+
+function ShowMessageList() {
+  const [testData, setTestData] = useState([]);
+  const [popularCurrentPage, setPopularCurrentPage] = useState(0);
+  const [recentCurrentPage, setRecentCurrentPage] = useState(0);
+  const [popularrecentShowCards, setPopularrecentShowCards] = useState([]);
+  const [recentShowCards, setRecentShowCards] = useState([]);
+  const cardCount = 4;
+
+  useEffect(() => {
+    setTestData(testDataFile);
+    // axiosInstance
+    //   .get("/18-3/recipients/?limit=5&offset=20")
+    //   .then((res) => {
+    //     setTestData(res.data);
+    //     console.log(res.data);
+    //   })
+    //   .catch((err) => {
+    //     console.error("오류:", err);
+    //   });
+  }, []);
+
+  const totalPages = Math.ceil(testData.length / cardCount);
+
+  useEffect(() => {
+    const startPageNum = recentCurrentPage * cardCount;
+    const endPageNum = startPageNum + cardCount;
+
+    const popularStartPageNum = popularCurrentPage * cardCount;
+    const popularEndPageNum = popularStartPageNum + cardCount;
+
+    /* createdAt(생성된 시점)에 따라서 정렬 */
+    setRecentShowCards(testData.slice(startPageNum, endPageNum));
+
+    /* 여기서 messageCount(메시지수)에 따라서 정렬 */
+    setPopularrecentShowCards(
+      testData.slice(popularStartPageNum, popularEndPageNum)
+    );
+  }, [popularCurrentPage, recentCurrentPage, testData]);
+
+  const nextPage = (mode) => {
+    if (mode) {
+      if (popularCurrentPage < totalPages - 1) {
+        setPopularCurrentPage((pprCurrentNum) => pprCurrentNum + 1);
+      }
+    } else {
+      if (recentCurrentPage < totalPages - 1) {
+        setRecentCurrentPage((currentNum) => currentNum + 1);
+      }
+    }
+  };
+
+  const prevPage = (mode) => {
+    if (mode) {
+      if (popularCurrentPage > 0) {
+        setPopularCurrentPage((pprCurrentNum) => pprCurrentNum - 1);
+      }
+    } else {
+      if (recentCurrentPage > 0) {
+        setRecentCurrentPage((currentNum) => currentNum - 1);
+      }
+    }
+  };
+
+  return (
+    <TopContainer>
+      <article>
+        <CardSection>
+          <CardTitle>인기 롤링 페이퍼 🔥</CardTitle>
+          <CardContainer>
+            {popularrecentShowCards.map((item) => (
+              <CardItem key={item.id} backgroundColor={item.backgroundColor}>
+                <h2>To. {item.name}</h2>
+                <div className="message-images">
+                  {item.recentMessages.slice(0, 3).map((messageItem, index) => (
+                    <img
+                      key={index}
+                      src={messageItem.profileImageURL}
+                      alt={`profile-${index}`}
+                      loading="lazy"
+                    />
+                  ))}
+                  {item.messageCount > 3 ? (
+                    <div className="over-profile">
+                      <span>+{item.messageCount - 3}</span>
+                    </div>
+                  ) : null}
+                </div>
+                <span>
+                  <strong>{item.messageCount}</strong>명이 작성했어요!
+                </span>
+                <div className="emoji-div">test</div>
+              </CardItem>
+            ))}
+            {popularCurrentPage > 0 ? (
+              <PrevBtnWpr onClick={() => prevPage("ppr")}>
+                <ArrowButton direction={ARROW_BUTTON_DIRECTION.left} />
+              </PrevBtnWpr>
+            ) : null}
+            {popularCurrentPage < totalPages - 1 ? (
+              <NextBtnWpr onClick={() => nextPage("ppr")}>
+                <ArrowButton direction={ARROW_BUTTON_DIRECTION.right} />
+              </NextBtnWpr>
+            ) : null}
+          </CardContainer>
+        </CardSection>
+
+        <CardSection>
+          <CardTitle>최근에 만든 롤링 페이퍼 ⭐</CardTitle>
+          <CardContainer>
+            {recentShowCards.map((item) => (
+              <CardItem key={item.id} backgroundColor={item.backgroundColor}>
+                <h2>To. {item.name}</h2>
+                <div className="message-images">
+                  {item.recentMessages.slice(0, 3).map((messageItem, index) => (
+                    <img
+                      key={index}
+                      src={messageItem.profileImageURL}
+                      alt={`profile-${index}`}
+                      loading="lazy"
+                    />
+                  ))}
+                  {item.messageCount > 3 ? (
+                    <div className="over-profile">
+                      <span>+{item.messageCount - 3}</span>
+                    </div>
+                  ) : null}
+                </div>
+                <span>
+                  <strong>{item.messageCount}</strong>명이 작성했어요!
+                </span>
+              </CardItem>
+            ))}
+            {recentCurrentPage > 0 ? (
+              <PrevBtnWpr onClick={() => prevPage()}>
+                <ArrowButton direction={ARROW_BUTTON_DIRECTION.left} />
+              </PrevBtnWpr>
+            ) : null}
+            {recentCurrentPage < totalPages - 1 ? (
+              <NextBtnWpr onClick={() => nextPage()}>
+                <ArrowButton direction={ARROW_BUTTON_DIRECTION.right} />
+              </NextBtnWpr>
+            ) : null}
+          </CardContainer>
+        </CardSection>
+      </article>
+      <MakingBtn size={BUTTON_SIZE.large} title="나도 만들어보기" />
+    </TopContainer>
+  );
+}
+
+export default ShowMessageList;

--- a/src/pages/rolling-paper-list-page.jsx
+++ b/src/pages/rolling-paper-list-page.jsx
@@ -96,7 +96,7 @@ const CardItem = styled.div`
   }
 `;
 
-const NextBtnWpr = styled.div`
+const NextButtonWrapper = styled.div`
   position: absolute;
   right: -20px;
   top: 50%;
@@ -104,7 +104,7 @@ const NextBtnWpr = styled.div`
   z-index: 10;
 `;
 
-const PrevBtnWpr = styled.div`
+const PreviewButtonWrapper = styled.div`
   position: absolute;
   left: -20px;
   top: 50%;
@@ -112,7 +112,7 @@ const PrevBtnWpr = styled.div`
   z-index: 10;
 `;
 
-const MakingBtn = styled(PrimaryButton)`
+const MakingButton = styled(PrimaryButton)`
   margin-top: 64px;
   font-weight: 400;
   padding: 14px 60px;
@@ -157,27 +157,17 @@ function ShowMessageList() {
     );
   }, [popularCurrentPage, recentCurrentPage, testData]);
 
-  const nextPage = (mode) => {
-    if (mode) {
-      if (popularCurrentPage < totalPages - 1) {
-        setPopularCurrentPage((pprCurrentNum) => pprCurrentNum + 1);
-      }
-    } else {
-      if (recentCurrentPage < totalPages - 1) {
-        setRecentCurrentPage((currentNum) => currentNum + 1);
-      }
-    }
-  };
+  const handleTurnCards = (direction, mode) => {
+    const current = mode === "popular" ? popularCurrentPage : recentCurrentPage;
+    const setter =
+      mode === "popular" ? setPopularCurrentPage : setRecentCurrentPage;
+    const total = totalPages;
 
-  const prevPage = (mode) => {
-    if (mode) {
-      if (popularCurrentPage > 0) {
-        setPopularCurrentPage((pprCurrentNum) => pprCurrentNum - 1);
-      }
-    } else {
-      if (recentCurrentPage > 0) {
-        setRecentCurrentPage((currentNum) => currentNum - 1);
-      }
+    const additionalPageIndex = direction === "next" ? 1 : -1;
+    const newPageIndex = current + additionalPageIndex;
+
+    if (newPageIndex >= 0 && newPageIndex < total) {
+      setter(newPageIndex);
     }
   };
 
@@ -212,14 +202,18 @@ function ShowMessageList() {
               </CardItem>
             ))}
             {popularCurrentPage > 0 ? (
-              <PrevBtnWpr onClick={() => prevPage("ppr")}>
+              <PreviewButtonWrapper
+                onClick={() => handleTurnCards("preview", "popular")}
+              >
                 <ArrowButton direction={ARROW_BUTTON_DIRECTION.left} />
-              </PrevBtnWpr>
+              </PreviewButtonWrapper>
             ) : null}
             {popularCurrentPage < totalPages - 1 ? (
-              <NextBtnWpr onClick={() => nextPage("ppr")}>
+              <NextButtonWrapper
+                onClick={() => handleTurnCards("next", "popular")}
+              >
                 <ArrowButton direction={ARROW_BUTTON_DIRECTION.right} />
-              </NextBtnWpr>
+              </NextButtonWrapper>
             ) : null}
           </CardContainer>
         </CardSection>
@@ -251,19 +245,23 @@ function ShowMessageList() {
               </CardItem>
             ))}
             {recentCurrentPage > 0 ? (
-              <PrevBtnWpr onClick={() => prevPage()}>
+              <PreviewButtonWrapper
+                onClick={() => handleTurnCards("preview", "recent")}
+              >
                 <ArrowButton direction={ARROW_BUTTON_DIRECTION.left} />
-              </PrevBtnWpr>
+              </PreviewButtonWrapper>
             ) : null}
             {recentCurrentPage < totalPages - 1 ? (
-              <NextBtnWpr onClick={() => nextPage()}>
+              <NextButtonWrapper
+                onClick={() => handleTurnCards("next", "recent")}
+              >
                 <ArrowButton direction={ARROW_BUTTON_DIRECTION.right} />
-              </NextBtnWpr>
+              </NextButtonWrapper>
             ) : null}
           </CardContainer>
         </CardSection>
       </article>
-      <MakingBtn size={BUTTON_SIZE.large} title="나도 만들어보기" />
+      <MakingButton size={BUTTON_SIZE.large} title="나도 만들어보기" />
     </TopContainer>
   );
 }

--- a/src/pages/test_recipients_data.json
+++ b/src/pages/test_recipients_data.json
@@ -1,7 +1,7 @@
 [
   {
     "id": 7024,
-    "name": "이병헌",
+    "name": "Suwon Kim",
     "backgroundColor": "beige",
     "backgroundImageURL": null,
     "createdAt": "2023-10-22T19:15:11Z",
@@ -151,10 +151,10 @@
       {
         "id": 30238,
         "recipientId": 43558,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/340/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 32",
+        "content": "Suwon Kim님의 메세지 내용 32",
         "font": "Nanum Gothic",
         "createdAt": "2023-06-17T00:31:29Z"
       },
@@ -263,7 +263,7 @@
   },
   {
     "id": 18499,
-    "name": "이병헌",
+    "name": "Suwon Kim",
     "backgroundColor": "beige",
     "backgroundImageURL": "https://picsum.photos/seed/18499/600/400",
     "createdAt": "2023-06-03T04:15:47Z",
@@ -272,10 +272,10 @@
       {
         "id": 48979,
         "recipientId": 18499,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/11/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 77",
+        "content": "Suwon Kim님의 메세지 내용 77",
         "font": "Nanum Gothic",
         "createdAt": "2023-08-25T00:15:25Z"
       },
@@ -292,10 +292,10 @@
       {
         "id": 35753,
         "recipientId": 18499,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/173/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 67",
+        "content": "Suwon Kim님의 메세지 내용 67",
         "font": "Nanum Gothic",
         "createdAt": "2023-07-23T23:14:30Z"
       }
@@ -467,7 +467,7 @@
   },
   {
     "id": 13425,
-    "name": "이병헌",
+    "name": "Suwon Kim",
     "backgroundColor": "beige",
     "backgroundImageURL": "https://picsum.photos/seed/13425/600/400",
     "createdAt": "2023-07-06T20:30:52Z",
@@ -567,10 +567,10 @@
       {
         "id": 34424,
         "recipientId": 97436,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/141/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 6",
+        "content": "Suwon Kim님의 메세지 내용 6",
         "font": "Nanum Gothic",
         "createdAt": "2023-06-01T12:35:35Z"
       },
@@ -616,7 +616,7 @@
   },
   {
     "id": 22932,
-    "name": "이병헌",
+    "name": "Suwon Kim",
     "backgroundColor": "blue",
     "backgroundImageURL": "https://picsum.photos/seed/22932/600/400",
     "createdAt": "2023-12-21T05:29:02Z",
@@ -779,10 +779,10 @@
       {
         "id": 88963,
         "recipientId": 2194,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/317/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 81",
+        "content": "Suwon Kim님의 메세지 내용 81",
         "font": "Nanum Gothic",
         "createdAt": "2023-03-12T08:38:10Z"
       }
@@ -992,7 +992,7 @@
   },
   {
     "id": 45901,
-    "name": "이병헌",
+    "name": "Suwon Kim",
     "backgroundColor": "purple",
     "backgroundImageURL": null,
     "createdAt": "2023-06-14T15:34:31Z",
@@ -1165,10 +1165,10 @@
       {
         "id": 99518,
         "recipientId": 84532,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/2/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 83",
+        "content": "Suwon Kim님의 메세지 내용 83",
         "font": "Nanum Gothic",
         "createdAt": "2023-07-12T22:08:05Z"
       },
@@ -1243,10 +1243,10 @@
       {
         "id": 72173,
         "recipientId": 85839,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/137/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 84",
+        "content": "Suwon Kim님의 메세지 내용 84",
         "font": "Pretendard",
         "createdAt": "2023-04-01T12:40:19Z"
       }
@@ -1359,10 +1359,10 @@
       {
         "id": 20559,
         "recipientId": 76172,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/315/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 53",
+        "content": "Suwon Kim님의 메세지 내용 53",
         "font": "Roboto",
         "createdAt": "2023-07-06T05:06:42Z"
       },
@@ -1475,10 +1475,10 @@
       {
         "id": 26243,
         "recipientId": 525,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/470/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 36",
+        "content": "Suwon Kim님의 메세지 내용 36",
         "font": "Noto Sans",
         "createdAt": "2024-02-01T22:09:11Z"
       },
@@ -1642,10 +1642,10 @@
       {
         "id": 8442,
         "recipientId": 76854,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/391/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 6",
+        "content": "Suwon Kim님의 메세지 내용 6",
         "font": "Pretendard",
         "createdAt": "2023-12-21T09:27:19Z"
       },
@@ -1690,10 +1690,10 @@
       {
         "id": 3111,
         "recipientId": 50919,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/384/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 80",
+        "content": "Suwon Kim님의 메세지 내용 80",
         "font": "Pretendard",
         "createdAt": "2023-08-12T11:51:00Z"
       },
@@ -1971,7 +1971,7 @@
   },
   {
     "id": 5465,
-    "name": "이병헌",
+    "name": "Suwon Kim",
     "backgroundColor": "beige",
     "backgroundImageURL": null,
     "createdAt": "2023-01-10T18:10:25Z",
@@ -2353,10 +2353,10 @@
       {
         "id": 66552,
         "recipientId": 90385,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/498/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 36",
+        "content": "Suwon Kim님의 메세지 내용 36",
         "font": "Noto Sans",
         "createdAt": "2023-10-17T11:54:41Z"
       }
@@ -2497,10 +2497,10 @@
       {
         "id": 59673,
         "recipientId": 39122,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/467/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 15",
+        "content": "Suwon Kim님의 메세지 내용 15",
         "font": "Nanum Gothic",
         "createdAt": "2023-03-20T07:58:11Z"
       },
@@ -2570,10 +2570,10 @@
       {
         "id": 87956,
         "recipientId": 36279,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/362/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 45",
+        "content": "Suwon Kim님의 메세지 내용 45",
         "font": "Pretendard",
         "createdAt": "2023-01-10T01:43:19Z"
       }
@@ -2802,10 +2802,10 @@
       {
         "id": 60985,
         "recipientId": 2640,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/440/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 52",
+        "content": "Suwon Kim님의 메세지 내용 52",
         "font": "Pretendard",
         "createdAt": "2023-05-11T23:03:58Z"
       },
@@ -3256,20 +3256,20 @@
       {
         "id": 96788,
         "recipientId": 73648,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/249/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 54",
+        "content": "Suwon Kim님의 메세지 내용 54",
         "font": "Nanum Gothic",
         "createdAt": "2023-09-16T01:58:06Z"
       },
       {
         "id": 20726,
         "recipientId": 73648,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/431/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 78",
+        "content": "Suwon Kim님의 메세지 내용 78",
         "font": "Pretendard",
         "createdAt": "2023-07-25T07:59:44Z"
       }
@@ -3725,10 +3725,10 @@
       {
         "id": 65998,
         "recipientId": 73391,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/117/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 7",
+        "content": "Suwon Kim님의 메세지 내용 7",
         "font": "Noto Sans",
         "createdAt": "2023-06-29T21:54:39Z"
       }
@@ -3953,7 +3953,7 @@
   },
   {
     "id": 26744,
-    "name": "이병헌",
+    "name": "Suwon Kim",
     "backgroundColor": "beige",
     "backgroundImageURL": null,
     "createdAt": "2023-03-23T03:14:00Z",
@@ -4098,10 +4098,10 @@
       {
         "id": 35228,
         "recipientId": 90477,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/94/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 63",
+        "content": "Suwon Kim님의 메세지 내용 63",
         "font": "Roboto",
         "createdAt": "2023-05-25T06:02:55Z"
       },
@@ -4457,7 +4457,7 @@
   },
   {
     "id": 31714,
-    "name": "이병헌",
+    "name": "Suwon Kim",
     "backgroundColor": "beige",
     "backgroundImageURL": "https://picsum.photos/seed/31714/600/400",
     "createdAt": "2023-01-13T08:26:56Z",
@@ -4529,10 +4529,10 @@
       {
         "id": 88820,
         "recipientId": 24976,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/355/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 72",
+        "content": "Suwon Kim님의 메세지 내용 72",
         "font": "Pretendard",
         "createdAt": "2023-12-02T16:28:28Z"
       }
@@ -4713,10 +4713,10 @@
       {
         "id": 35658,
         "recipientId": 9191,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/62/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 27",
+        "content": "Suwon Kim님의 메세지 내용 27",
         "font": "Nanum Gothic",
         "createdAt": "2023-04-09T12:56:46Z"
       },
@@ -4733,10 +4733,10 @@
       {
         "id": 20041,
         "recipientId": 9191,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/114/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 72",
+        "content": "Suwon Kim님의 메세지 내용 72",
         "font": "Pretendard",
         "createdAt": "2023-11-11T12:43:30Z"
       }
@@ -4834,10 +4834,10 @@
       {
         "id": 53736,
         "recipientId": 625,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/411/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 98",
+        "content": "Suwon Kim님의 메세지 내용 98",
         "font": "Nanum Gothic",
         "createdAt": "2023-06-06T17:47:12Z"
       },
@@ -4907,10 +4907,10 @@
       {
         "id": 53607,
         "recipientId": 23417,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/402/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 96",
+        "content": "Suwon Kim님의 메세지 내용 96",
         "font": "Noto Sans",
         "createdAt": "2023-06-28T04:25:20Z"
       }
@@ -5081,10 +5081,10 @@
       {
         "id": 76625,
         "recipientId": 48647,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/256/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 98",
+        "content": "Suwon Kim님의 메세지 내용 98",
         "font": "Pretendard",
         "createdAt": "2023-03-21T02:42:08Z"
       },
@@ -5144,10 +5144,10 @@
       {
         "id": 90888,
         "recipientId": 7110,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/19/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 42",
+        "content": "Suwon Kim님의 메세지 내용 42",
         "font": "Roboto",
         "createdAt": "2023-09-16T18:15:50Z"
       },
@@ -5256,7 +5256,7 @@
   },
   {
     "id": 75973,
-    "name": "이병헌",
+    "name": "Suwon Kim",
     "backgroundColor": "beige",
     "backgroundImageURL": "https://picsum.photos/seed/75973/600/400",
     "createdAt": "2023-04-29T23:14:33Z",
@@ -5265,10 +5265,10 @@
       {
         "id": 85401,
         "recipientId": 75973,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/269/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 90",
+        "content": "Suwon Kim님의 메세지 내용 90",
         "font": "Noto Sans",
         "createdAt": "2023-11-12T05:17:44Z"
       },
@@ -5755,7 +5755,7 @@
   },
   {
     "id": 32314,
-    "name": "이병헌",
+    "name": "Suwon Kim",
     "backgroundColor": "purple",
     "backgroundImageURL": null,
     "createdAt": "2023-06-09T07:16:23Z",
@@ -5774,10 +5774,10 @@
       {
         "id": 10034,
         "recipientId": 32314,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/288/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 22",
+        "content": "Suwon Kim님의 메세지 내용 22",
         "font": "Pretendard",
         "createdAt": "2023-09-14T13:27:24Z"
       },
@@ -5938,10 +5938,10 @@
       {
         "id": 50489,
         "recipientId": 63219,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/11/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 77",
+        "content": "Suwon Kim님의 메세지 내용 77",
         "font": "Noto Sans",
         "createdAt": "2023-11-27T08:16:32Z"
       }
@@ -5962,7 +5962,7 @@
   },
   {
     "id": 32218,
-    "name": "이병헌",
+    "name": "Suwon Kim",
     "backgroundColor": "beige",
     "backgroundImageURL": null,
     "createdAt": "2023-07-22T22:33:51Z",
@@ -6107,10 +6107,10 @@
       {
         "id": 24988,
         "recipientId": 1341,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/423/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 64",
+        "content": "Suwon Kim님의 메세지 내용 64",
         "font": "Roboto",
         "createdAt": "2023-01-06T05:53:05Z"
       }
@@ -6184,7 +6184,7 @@
   },
   {
     "id": 93438,
-    "name": "이병헌",
+    "name": "Suwon Kim",
     "backgroundColor": "blue",
     "backgroundImageURL": "https://picsum.photos/seed/93438/600/400",
     "createdAt": "2023-04-02T11:00:53Z",
@@ -6203,10 +6203,10 @@
       {
         "id": 6156,
         "recipientId": 93438,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/109/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 59",
+        "content": "Suwon Kim님의 메세지 내용 59",
         "font": "Noto Sans",
         "createdAt": "2023-01-24T10:30:39Z"
       },
@@ -6232,7 +6232,7 @@
   },
   {
     "id": 44334,
-    "name": "이병헌",
+    "name": "Suwon Kim",
     "backgroundColor": "blue",
     "backgroundImageURL": "https://picsum.photos/seed/44334/600/400",
     "createdAt": "2023-12-30T01:42:47Z",
@@ -6353,7 +6353,7 @@
   },
   {
     "id": 44928,
-    "name": "이병헌",
+    "name": "Suwon Kim",
     "backgroundColor": "beige",
     "backgroundImageURL": null,
     "createdAt": "2023-11-24T12:12:26Z",
@@ -6405,10 +6405,10 @@
       {
         "id": 31761,
         "recipientId": 94539,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/62/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 53",
+        "content": "Suwon Kim님의 메세지 내용 53",
         "font": "Pretendard",
         "createdAt": "2023-04-17T18:23:36Z"
       },
@@ -6970,10 +6970,10 @@
       {
         "id": 41596,
         "recipientId": 43809,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/439/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 36",
+        "content": "Suwon Kim님의 메세지 내용 36",
         "font": "Roboto",
         "createdAt": "2023-02-12T07:13:07Z"
       },
@@ -7086,10 +7086,10 @@
       {
         "id": 62162,
         "recipientId": 62125,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/293/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 93",
+        "content": "Suwon Kim님의 메세지 내용 93",
         "font": "Roboto",
         "createdAt": "2023-04-29T23:05:56Z"
       }
@@ -7207,10 +7207,10 @@
       {
         "id": 91516,
         "recipientId": 58844,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/108/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 82",
+        "content": "Suwon Kim님의 메세지 내용 82",
         "font": "Pretendard",
         "createdAt": "2023-08-27T12:05:46Z"
       }
@@ -7260,10 +7260,10 @@
       {
         "id": 29903,
         "recipientId": 72437,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/106/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 40",
+        "content": "Suwon Kim님의 메세지 내용 40",
         "font": "Roboto",
         "createdAt": "2023-04-29T16:49:48Z"
       }
@@ -7323,10 +7323,10 @@
       {
         "id": 91691,
         "recipientId": 31124,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/461/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 53",
+        "content": "Suwon Kim님의 메세지 내용 53",
         "font": "Roboto",
         "createdAt": "2023-05-21T09:55:42Z"
       }
@@ -7347,7 +7347,7 @@
   },
   {
     "id": 73111,
-    "name": "이병헌",
+    "name": "Suwon Kim",
     "backgroundColor": "blue",
     "backgroundImageURL": null,
     "createdAt": "2023-12-29T11:24:51Z",
@@ -7419,10 +7419,10 @@
       {
         "id": 2974,
         "recipientId": 44599,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/46/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 13",
+        "content": "Suwon Kim님의 메세지 내용 13",
         "font": "Roboto",
         "createdAt": "2023-11-11T07:56:34Z"
       },
@@ -7710,7 +7710,7 @@
   },
   {
     "id": 72332,
-    "name": "이병헌",
+    "name": "Suwon Kim",
     "backgroundColor": "purple",
     "backgroundImageURL": "https://picsum.photos/seed/72332/600/400",
     "createdAt": "2023-10-08T20:12:12Z",
@@ -7815,10 +7815,10 @@
       {
         "id": 47612,
         "recipientId": 6048,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/97/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 72",
+        "content": "Suwon Kim님의 메세지 내용 72",
         "font": "Pretendard",
         "createdAt": "2023-12-11T12:42:57Z"
       },
@@ -7888,10 +7888,10 @@
       {
         "id": 54283,
         "recipientId": 7768,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/368/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 8",
+        "content": "Suwon Kim님의 메세지 내용 8",
         "font": "Nanum Gothic",
         "createdAt": "2023-02-19T15:25:55Z"
       },
@@ -7946,10 +7946,10 @@
       {
         "id": 66344,
         "recipientId": 60032,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/444/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 47",
+        "content": "Suwon Kim님의 메세지 내용 47",
         "font": "Pretendard",
         "createdAt": "2023-07-26T07:54:55Z"
       }
@@ -8418,10 +8418,10 @@
       {
         "id": 48175,
         "recipientId": 96506,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/145/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 86",
+        "content": "Suwon Kim님의 메세지 내용 86",
         "font": "Pretendard",
         "createdAt": "2023-03-13T10:17:35Z"
       },
@@ -8607,10 +8607,10 @@
       {
         "id": 11805,
         "recipientId": 10732,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/76/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 48",
+        "content": "Suwon Kim님의 메세지 내용 48",
         "font": "Nanum Gothic",
         "createdAt": "2023-12-29T05:06:21Z"
       }
@@ -8708,10 +8708,10 @@
       {
         "id": 94450,
         "recipientId": 64061,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/353/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 61",
+        "content": "Suwon Kim님의 메세지 내용 61",
         "font": "Pretendard",
         "createdAt": "2023-12-02T06:48:01Z"
       },
@@ -8737,7 +8737,7 @@
   },
   {
     "id": 15549,
-    "name": "이병헌",
+    "name": "Suwon Kim",
     "backgroundColor": "blue",
     "backgroundImageURL": null,
     "createdAt": "2023-12-13T10:07:11Z",
@@ -8819,10 +8819,10 @@
       {
         "id": 67124,
         "recipientId": 84213,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/482/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 81",
+        "content": "Suwon Kim님의 메세지 내용 81",
         "font": "Pretendard",
         "createdAt": "2023-04-16T14:42:59Z"
       },
@@ -8930,10 +8930,10 @@
       {
         "id": 91701,
         "recipientId": 83558,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/169/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 97",
+        "content": "Suwon Kim님의 메세지 내용 97",
         "font": "Noto Sans",
         "createdAt": "2023-11-22T09:50:03Z"
       },
@@ -9061,10 +9061,10 @@
       {
         "id": 86215,
         "recipientId": 1220,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/419/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 25",
+        "content": "Suwon Kim님의 메세지 내용 25",
         "font": "Pretendard",
         "createdAt": "2023-05-10T21:59:12Z"
       }
@@ -9085,7 +9085,7 @@
   },
   {
     "id": 53959,
-    "name": "이병헌",
+    "name": "Suwon Kim",
     "backgroundColor": "blue",
     "backgroundImageURL": "https://picsum.photos/seed/53959/600/400",
     "createdAt": "2023-08-24T05:22:48Z",
@@ -9114,10 +9114,10 @@
       {
         "id": 59151,
         "recipientId": 53959,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/10/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 4",
+        "content": "Suwon Kim님의 메세지 내용 4",
         "font": "Nanum Gothic",
         "createdAt": "2023-03-11T07:04:18Z"
       }
@@ -9216,7 +9216,7 @@
   },
   {
     "id": 51432,
-    "name": "이병헌",
+    "name": "Suwon Kim",
     "backgroundColor": "beige",
     "backgroundImageURL": "https://picsum.photos/seed/51432/600/400",
     "createdAt": "2023-11-07T07:07:37Z",
@@ -9235,10 +9235,10 @@
       {
         "id": 33808,
         "recipientId": 51432,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/478/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 8",
+        "content": "Suwon Kim님의 메세지 내용 8",
         "font": "Pretendard",
         "createdAt": "2023-04-04T10:06:15Z"
       },
@@ -9742,10 +9742,10 @@
       {
         "id": 93059,
         "recipientId": 73798,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/252/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 99",
+        "content": "Suwon Kim님의 메세지 내용 99",
         "font": "Roboto",
         "createdAt": "2023-11-21T09:01:45Z"
       },
@@ -9868,10 +9868,10 @@
       {
         "id": 33941,
         "recipientId": 3992,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/364/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 93",
+        "content": "Suwon Kim님의 메세지 내용 93",
         "font": "Pretendard",
         "createdAt": "2023-02-13T23:03:26Z"
       },
@@ -9964,10 +9964,10 @@
       {
         "id": 89359,
         "recipientId": 63758,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/401/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 53",
+        "content": "Suwon Kim님의 메세지 내용 53",
         "font": "Roboto",
         "createdAt": "2023-05-10T19:04:15Z"
       },
@@ -10084,7 +10084,7 @@
   },
   {
     "id": 63096,
-    "name": "이병헌",
+    "name": "Suwon Kim",
     "backgroundColor": "blue",
     "backgroundImageURL": "https://picsum.photos/seed/63096/600/400",
     "createdAt": "2023-08-25T09:30:08Z",
@@ -10093,10 +10093,10 @@
       {
         "id": 72995,
         "recipientId": 63096,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/368/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 44",
+        "content": "Suwon Kim님의 메세지 내용 44",
         "font": "Pretendard",
         "createdAt": "2023-10-07T18:41:59Z"
       },
@@ -10151,10 +10151,10 @@
       {
         "id": 44494,
         "recipientId": 13289,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/118/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 64",
+        "content": "Suwon Kim님의 메세지 내용 64",
         "font": "Nanum Gothic",
         "createdAt": "2024-01-29T16:37:33Z"
       },
@@ -10534,10 +10534,10 @@
       {
         "id": 33150,
         "recipientId": 66190,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/26/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 47",
+        "content": "Suwon Kim님의 메세지 내용 47",
         "font": "Roboto",
         "createdAt": "2024-01-22T00:03:15Z"
       }
@@ -10558,7 +10558,7 @@
   },
   {
     "id": 68635,
-    "name": "이병헌",
+    "name": "Suwon Kim",
     "backgroundColor": "beige",
     "backgroundImageURL": null,
     "createdAt": "2023-10-22T10:14:45Z",
@@ -10625,10 +10625,10 @@
       {
         "id": 8378,
         "recipientId": 52236,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/383/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 53",
+        "content": "Suwon Kim님의 메세지 내용 53",
         "font": "Pretendard",
         "createdAt": "2023-12-03T19:03:51Z"
       }
@@ -10663,10 +10663,10 @@
       {
         "id": 14027,
         "recipientId": 81115,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/400/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 48",
+        "content": "Suwon Kim님의 메세지 내용 48",
         "font": "Noto Sans",
         "createdAt": "2023-09-18T14:09:01Z"
       },
@@ -10885,10 +10885,10 @@
       {
         "id": 16314,
         "recipientId": 60,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/345/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 52",
+        "content": "Suwon Kim님의 메세지 내용 52",
         "font": "Roboto",
         "createdAt": "2023-03-07T04:55:33Z"
       }
@@ -10928,10 +10928,10 @@
       {
         "id": 81467,
         "recipientId": 66554,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/487/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 17",
+        "content": "Suwon Kim님의 메세지 내용 17",
         "font": "Nanum Gothic",
         "createdAt": "2023-03-16T05:19:39Z"
       },
@@ -11155,10 +11155,10 @@
       {
         "id": 19962,
         "recipientId": 31459,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/80/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 11",
+        "content": "Suwon Kim님의 메세지 내용 11",
         "font": "Nanum Gothic",
         "createdAt": "2023-11-26T04:31:20Z"
       }
@@ -11402,10 +11402,10 @@
       {
         "id": 24156,
         "recipientId": 41885,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/360/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 14",
+        "content": "Suwon Kim님의 메세지 내용 14",
         "font": "Noto Sans",
         "createdAt": "2023-07-13T21:35:18Z"
       },
@@ -11816,20 +11816,20 @@
       {
         "id": 86564,
         "recipientId": 46642,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/36/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 78",
+        "content": "Suwon Kim님의 메세지 내용 78",
         "font": "Noto Sans",
         "createdAt": "2023-09-23T23:48:17Z"
       },
       {
         "id": 46880,
         "recipientId": 46642,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/453/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 92",
+        "content": "Suwon Kim님의 메세지 내용 92",
         "font": "Noto Sans",
         "createdAt": "2023-06-07T09:44:08Z"
       },
@@ -11928,7 +11928,7 @@
   },
   {
     "id": 93469,
-    "name": "이병헌",
+    "name": "Suwon Kim",
     "backgroundColor": "beige",
     "backgroundImageURL": "https://picsum.photos/seed/93469/600/400",
     "createdAt": "2023-08-05T08:37:01Z",
@@ -11991,7 +11991,7 @@
   },
   {
     "id": 45950,
-    "name": "이병헌",
+    "name": "Suwon Kim",
     "backgroundColor": "green",
     "backgroundImageURL": "https://picsum.photos/seed/45950/600/400",
     "createdAt": "2023-04-24T21:39:46Z",
@@ -12489,10 +12489,10 @@
       {
         "id": 46241,
         "recipientId": 30047,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/397/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 64",
+        "content": "Suwon Kim님의 메세지 내용 64",
         "font": "Roboto",
         "createdAt": "2023-04-12T04:50:45Z"
       },
@@ -12833,7 +12833,7 @@
   },
   {
     "id": 44091,
-    "name": "이병헌",
+    "name": "Suwon Kim",
     "backgroundColor": "blue",
     "backgroundImageURL": "https://picsum.photos/seed/44091/600/400",
     "createdAt": "2023-06-17T19:51:45Z",
@@ -13349,10 +13349,10 @@
       {
         "id": 58525,
         "recipientId": 62965,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/103/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 1",
+        "content": "Suwon Kim님의 메세지 내용 1",
         "font": "Noto Sans",
         "createdAt": "2023-04-24T14:22:46Z"
       },
@@ -13387,10 +13387,10 @@
       {
         "id": 86114,
         "recipientId": 61614,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/1/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 48",
+        "content": "Suwon Kim님의 메세지 내용 48",
         "font": "Noto Sans",
         "createdAt": "2023-11-16T04:24:55Z"
       },
@@ -13494,7 +13494,7 @@
   },
   {
     "id": 31146,
-    "name": "이병헌",
+    "name": "Suwon Kim",
     "backgroundColor": "green",
     "backgroundImageURL": null,
     "createdAt": "2023-09-27T13:42:38Z",
@@ -13551,10 +13551,10 @@
       {
         "id": 80875,
         "recipientId": 99123,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/42/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 14",
+        "content": "Suwon Kim님의 메세지 내용 14",
         "font": "Roboto",
         "createdAt": "2023-11-30T19:44:40Z"
       },
@@ -13682,10 +13682,10 @@
       {
         "id": 9237,
         "recipientId": 16143,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/437/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 14",
+        "content": "Suwon Kim님의 메세지 내용 14",
         "font": "Pretendard",
         "createdAt": "2023-03-17T21:44:08Z"
       }
@@ -13793,10 +13793,10 @@
       {
         "id": 31892,
         "recipientId": 98422,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/8/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 43",
+        "content": "Suwon Kim님의 메세지 내용 43",
         "font": "Pretendard",
         "createdAt": "2023-09-02T03:23:20Z"
       }
@@ -13841,10 +13841,10 @@
       {
         "id": 85445,
         "recipientId": 53532,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/363/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 51",
+        "content": "Suwon Kim님의 메세지 내용 51",
         "font": "Noto Sans",
         "createdAt": "2023-09-23T11:29:56Z"
       },
@@ -13904,10 +13904,10 @@
       {
         "id": 86518,
         "recipientId": 93792,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/204/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 9",
+        "content": "Suwon Kim님의 메세지 내용 9",
         "font": "Roboto",
         "createdAt": "2023-01-22T13:44:09Z"
       },
@@ -13924,10 +13924,10 @@
       {
         "id": 9752,
         "recipientId": 93792,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/171/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 68",
+        "content": "Suwon Kim님의 메세지 내용 68",
         "font": "Roboto",
         "createdAt": "2023-02-15T23:39:35Z"
       }
@@ -13992,10 +13992,10 @@
       {
         "id": 84648,
         "recipientId": 12242,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/112/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 4",
+        "content": "Suwon Kim님의 메세지 내용 4",
         "font": "Pretendard",
         "createdAt": "2024-01-06T11:37:10Z"
       }
@@ -14098,10 +14098,10 @@
       {
         "id": 35816,
         "recipientId": 76148,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/488/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 96",
+        "content": "Suwon Kim님의 메세지 내용 96",
         "font": "Nanum Gothic",
         "createdAt": "2023-04-09T14:21:56Z"
       }
@@ -14179,10 +14179,10 @@
       {
         "id": 76780,
         "recipientId": 38642,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/253/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 24",
+        "content": "Suwon Kim님의 메세지 내용 24",
         "font": "Nanum Gothic",
         "createdAt": "2023-07-12T11:54:03Z"
       },
@@ -14391,10 +14391,10 @@
       {
         "id": 78207,
         "recipientId": 55884,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/155/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 87",
+        "content": "Suwon Kim님의 메세지 내용 87",
         "font": "Pretendard",
         "createdAt": "2023-06-01T07:21:37Z"
       },
@@ -14454,10 +14454,10 @@
       {
         "id": 2300,
         "recipientId": 65809,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/358/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 60",
+        "content": "Suwon Kim님의 메세지 내용 60",
         "font": "Roboto",
         "createdAt": "2023-05-12T09:25:19Z"
       },
@@ -14527,10 +14527,10 @@
       {
         "id": 12155,
         "recipientId": 47549,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/247/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 80",
+        "content": "Suwon Kim님의 메세지 내용 80",
         "font": "Pretendard",
         "createdAt": "2023-03-09T22:19:14Z"
       },
@@ -14620,10 +14620,10 @@
       {
         "id": 64811,
         "recipientId": 7135,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/184/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 9",
+        "content": "Suwon Kim님의 메세지 내용 9",
         "font": "Roboto",
         "createdAt": "2023-10-17T00:36:13Z"
       }
@@ -15117,10 +15117,10 @@
       {
         "id": 65322,
         "recipientId": 21977,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/156/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 79",
+        "content": "Suwon Kim님의 메세지 내용 79",
         "font": "Nanum Gothic",
         "createdAt": "2023-09-13T04:30:55Z"
       }
@@ -15155,10 +15155,10 @@
       {
         "id": 37649,
         "recipientId": 67245,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/160/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 84",
+        "content": "Suwon Kim님의 메세지 내용 84",
         "font": "Roboto",
         "createdAt": "2023-05-09T12:36:18Z"
       },
@@ -15654,10 +15654,10 @@
       {
         "id": 7778,
         "recipientId": 37498,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/202/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 24",
+        "content": "Suwon Kim님의 메세지 내용 24",
         "font": "Pretendard",
         "createdAt": "2023-12-27T07:03:22Z"
       },
@@ -15887,7 +15887,7 @@
   },
   {
     "id": 12700,
-    "name": "이병헌",
+    "name": "Suwon Kim",
     "backgroundColor": "purple",
     "backgroundImageURL": null,
     "createdAt": "2023-08-18T22:43:12Z",
@@ -15916,10 +15916,10 @@
       {
         "id": 4746,
         "recipientId": 12700,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/260/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 44",
+        "content": "Suwon Kim님의 메세지 내용 44",
         "font": "Noto Sans",
         "createdAt": "2023-02-17T03:59:23Z"
       }
@@ -16181,10 +16181,10 @@
       {
         "id": 47661,
         "recipientId": 56031,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/395/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 62",
+        "content": "Suwon Kim님의 메세지 내용 62",
         "font": "Nanum Gothic",
         "createdAt": "2023-08-20T17:27:35Z"
       },
@@ -17115,7 +17115,7 @@
   },
   {
     "id": 31249,
-    "name": "이병헌",
+    "name": "Suwon Kim",
     "backgroundColor": "blue",
     "backgroundImageURL": null,
     "createdAt": "2023-05-16T17:41:45Z",
@@ -17134,10 +17134,10 @@
       {
         "id": 54855,
         "recipientId": 31249,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/188/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 84",
+        "content": "Suwon Kim님의 메세지 내용 84",
         "font": "Pretendard",
         "createdAt": "2023-07-01T14:34:04Z"
       }
@@ -17163,7 +17163,7 @@
   },
   {
     "id": 87008,
-    "name": "이병헌",
+    "name": "Suwon Kim",
     "backgroundColor": "purple",
     "backgroundImageURL": null,
     "createdAt": "2023-05-31T18:24:49Z",
@@ -17182,10 +17182,10 @@
       {
         "id": 29069,
         "recipientId": 87008,
-        "sender": "이병헌",
+        "sender": "Suwon Kim",
         "profileImageURL": "https://picsum.photos/id/25/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 19",
+        "content": "Suwon Kim님의 메세지 내용 19",
         "font": "Roboto",
         "createdAt": "2024-01-14T03:59:30Z"
       },

--- a/src/pages/test_recipients_data.json
+++ b/src/pages/test_recipients_data.json
@@ -1,0 +1,17227 @@
+[
+  {
+    "id": 7024,
+    "name": "이병헌",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-10-22T19:15:11Z",
+    "messageCount": 5,
+    "recentMessages": [
+      {
+        "id": 90163,
+        "recipientId": 7024,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/142/200/200",
+        "relationship": "친구",
+        "content": "김하은님의 메세지 내용 50",
+        "font": "Roboto",
+        "createdAt": "2023-08-18T21:20:29Z"
+      },
+      {
+        "id": 90164,
+        "recipientId": 7024,
+        "sender": "강동원",
+        "profileImageURL": "https://picsum.photos/id/142/200/200",
+        "relationship": "친구",
+        "content": "강동원님의 메세지 내용 50",
+        "font": "Roboto",
+        "createdAt": "2023-08-19T21:20:29Z"
+      },
+      {
+        "id": 90165,
+        "recipientId": 7024,
+        "sender": "고수",
+        "profileImageURL": "https://picsum.photos/id/142/200/200",
+        "relationship": "친구",
+        "content": "고수님의 메세지 내용 50",
+        "font": "Roboto",
+        "createdAt": "2023-08-20T21:20:29Z"
+      }
+    ],
+    "reactionCount": 77,
+    "topReactions": [
+      {
+        "id": 78000,
+        "emoji": "😁",
+        "count": 6
+      },
+      {
+        "id": 70479,
+        "emoji": "🥹",
+        "count": 15
+      },
+      {
+        "id": 32001,
+        "emoji": "😁",
+        "count": 5
+      },
+      {
+        "id": 25196,
+        "emoji": "🥹",
+        "count": 18
+      },
+      {
+        "id": 15685,
+        "emoji": "🥹",
+        "count": 2
+      }
+    ]
+  },
+  {
+    "id": 71200,
+    "name": "박서준",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/71200/600/400",
+    "createdAt": "2023-01-03T05:35:33Z",
+    "messageCount": 5,
+    "recentMessages": [
+      {
+        "id": 42811,
+        "recipientId": 71200,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/435/200/200",
+        "relationship": "가족",
+        "content": "현빈님의 메세지 내용 25",
+        "font": "Roboto",
+        "createdAt": "2023-06-23T06:13:02Z"
+      },
+      {
+        "id": 32677,
+        "recipientId": 71200,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/435/200/200",
+        "relationship": "지인",
+        "content": "정우성님의 메세지 내용 28",
+        "font": "Roboto",
+        "createdAt": "2023-01-27T19:16:37Z"
+      },
+      {
+        "id": 19164,
+        "recipientId": 71200,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/54/200/200",
+        "relationship": "동료",
+        "content": "송혜교님의 메세지 내용 73",
+        "font": "Nanum Gothic",
+        "createdAt": "2024-01-13T10:43:25Z"
+      }
+    ],
+    "reactionCount": 66,
+    "topReactions": [
+      {
+        "id": 84284,
+        "emoji": "🥹",
+        "count": 4
+      },
+      {
+        "id": 67905,
+        "emoji": "😁",
+        "count": 2
+      },
+      {
+        "id": 19092,
+        "emoji": "👍",
+        "count": 4
+      },
+      {
+        "id": 62998,
+        "emoji": "😁",
+        "count": 5
+      },
+      {
+        "id": 49907,
+        "emoji": "🥹",
+        "count": 10
+      },
+      {
+        "id": 306,
+        "emoji": "🥹",
+        "count": 3
+      }
+    ]
+  },
+  {
+    "id": 43558,
+    "name": "현빈",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-12-11T02:38:21Z",
+    "messageCount": 5,
+    "recentMessages": [
+      {
+        "id": 30238,
+        "recipientId": 43558,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/340/200/200",
+        "relationship": "가족",
+        "content": "이병헌님의 메세지 내용 32",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-06-17T00:31:29Z"
+      },
+      {
+        "id": 87763,
+        "recipientId": 43558,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/259/200/200",
+        "relationship": "동료",
+        "content": "정우성님의 메세지 내용 96",
+        "font": "Pretendard",
+        "createdAt": "2023-08-07T07:41:19Z"
+      },
+      {
+        "id": 67784,
+        "recipientId": 43558,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/300/200/200",
+        "relationship": "지인",
+        "content": "이영준님의 메세지 내용 73",
+        "font": "Nanum Gothic",
+        "createdAt": "2024-01-17T09:44:31Z"
+      }
+    ],
+    "reactionCount": 13,
+    "topReactions": [
+      {
+        "id": 84326,
+        "emoji": "😀",
+        "count": 13
+      },
+      {
+        "id": 29537,
+        "emoji": "🥹",
+        "count": 2
+      },
+      {
+        "id": 78412,
+        "emoji": "😁",
+        "count": 4
+      },
+      {
+        "id": 91457,
+        "emoji": "🎉",
+        "count": 6
+      },
+      {
+        "id": 50902,
+        "emoji": "🥹",
+        "count": 7
+      },
+      {
+        "id": 5434,
+        "emoji": "🥹",
+        "count": 14
+      }
+    ]
+  },
+  {
+    "id": 90454,
+    "name": "김하은",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/90454/600/400",
+    "createdAt": "2023-01-25T17:12:55Z",
+    "messageCount": 2,
+    "recentMessages": [
+      {
+        "id": 3505,
+        "recipientId": 90454,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/239/200/200",
+        "relationship": "가족",
+        "content": "박서준님의 메세지 내용 17",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-06-17T18:32:49Z"
+      },
+      {
+        "id": 38476,
+        "recipientId": 90454,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/13/200/200",
+        "relationship": "지인",
+        "content": "박서준님의 메세지 내용 89",
+        "font": "Pretendard",
+        "createdAt": "2023-01-20T02:06:16Z"
+      }
+    ],
+    "reactionCount": 84,
+    "topReactions": [
+      {
+        "id": 605,
+        "emoji": "🥹",
+        "count": 14
+      },
+      {
+        "id": 90894,
+        "emoji": "🥹",
+        "count": 3
+      },
+      {
+        "id": 26499,
+        "emoji": "🥹",
+        "count": 5
+      }
+    ]
+  },
+  {
+    "id": 18499,
+    "name": "이병헌",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/18499/600/400",
+    "createdAt": "2023-06-03T04:15:47Z",
+    "messageCount": 10,
+    "recentMessages": [
+      {
+        "id": 48979,
+        "recipientId": 18499,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/11/200/200",
+        "relationship": "지인",
+        "content": "이병헌님의 메세지 내용 77",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-08-25T00:15:25Z"
+      },
+      {
+        "id": 99385,
+        "recipientId": 18499,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/287/200/200",
+        "relationship": "지인",
+        "content": "최민수님의 메세지 내용 15",
+        "font": "Pretendard",
+        "createdAt": "2023-10-12T13:55:45Z"
+      },
+      {
+        "id": 35753,
+        "recipientId": 18499,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/173/200/200",
+        "relationship": "친구",
+        "content": "이병헌님의 메세지 내용 67",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-07-23T23:14:30Z"
+      }
+    ],
+    "reactionCount": 61,
+    "topReactions": [
+      {
+        "id": 84545,
+        "emoji": "👍",
+        "count": 2
+      },
+      {
+        "id": 91678,
+        "emoji": "❤️",
+        "count": 10
+      },
+      {
+        "id": 13771,
+        "emoji": "😀",
+        "count": 20
+      },
+      {
+        "id": 45654,
+        "emoji": "❤️",
+        "count": 2
+      },
+      {
+        "id": 97554,
+        "emoji": "🥹",
+        "count": 6
+      },
+      {
+        "id": 78344,
+        "emoji": "👍",
+        "count": 1
+      }
+    ]
+  },
+  {
+    "id": 84206,
+    "name": "정우성",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2023-11-30T22:40:21Z",
+    "messageCount": 10,
+    "recentMessages": [
+      {
+        "id": 5762,
+        "recipientId": 84206,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/474/200/200",
+        "relationship": "동료",
+        "content": "전지현님의 메세지 내용 31",
+        "font": "Pretendard",
+        "createdAt": "2023-04-24T12:23:57Z"
+      },
+      {
+        "id": 45324,
+        "recipientId": 84206,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/264/200/200",
+        "relationship": "지인",
+        "content": "한지민님의 메세지 내용 84",
+        "font": "Pretendard",
+        "createdAt": "2023-09-30T14:29:23Z"
+      },
+      {
+        "id": 14049,
+        "recipientId": 84206,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/406/200/200",
+        "relationship": "친구",
+        "content": "현빈님의 메세지 내용 15",
+        "font": "Noto Sans",
+        "createdAt": "2023-04-15T06:15:06Z"
+      }
+    ],
+    "reactionCount": 14,
+    "topReactions": [
+      {
+        "id": 5423,
+        "emoji": "😁",
+        "count": 19
+      },
+      {
+        "id": 694,
+        "emoji": "😀",
+        "count": 2
+      },
+      {
+        "id": 2845,
+        "emoji": "🥹",
+        "count": 13
+      },
+      {
+        "id": 90938,
+        "emoji": "🥹",
+        "count": 19
+      }
+    ]
+  },
+  {
+    "id": 97449,
+    "name": "송혜교",
+    "backgroundColor": "green",
+    "backgroundImageURL": null,
+    "createdAt": "2023-05-27T18:06:58Z",
+    "messageCount": 5,
+    "recentMessages": [
+      {
+        "id": 64517,
+        "recipientId": 97449,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/180/200/200",
+        "relationship": "지인",
+        "content": "현빈님의 메세지 내용 39",
+        "font": "Roboto",
+        "createdAt": "2023-03-11T02:20:57Z"
+      },
+      {
+        "id": 95376,
+        "recipientId": 97449,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/443/200/200",
+        "relationship": "가족",
+        "content": "최민수님의 메세지 내용 29",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-03-18T20:25:35Z"
+      },
+      {
+        "id": 7602,
+        "recipientId": 97449,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/18/200/200",
+        "relationship": "동료",
+        "content": "이영준님의 메세지 내용 57",
+        "font": "Roboto",
+        "createdAt": "2023-12-04T21:16:03Z"
+      }
+    ],
+    "reactionCount": 87,
+    "topReactions": [
+      {
+        "id": 71912,
+        "emoji": "😀",
+        "count": 1
+      },
+      {
+        "id": 53543,
+        "emoji": "❤️",
+        "count": 12
+      },
+      {
+        "id": 90369,
+        "emoji": "😀",
+        "count": 11
+      },
+      {
+        "id": 65448,
+        "emoji": "😁",
+        "count": 17
+      },
+      {
+        "id": 96672,
+        "emoji": "👍",
+        "count": 15
+      }
+    ]
+  },
+  {
+    "id": 13425,
+    "name": "이병헌",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/13425/600/400",
+    "createdAt": "2023-07-06T20:30:52Z",
+    "messageCount": 1,
+    "recentMessages": [
+      {
+        "id": 74302,
+        "recipientId": 13425,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/244/200/200",
+        "relationship": "가족",
+        "content": "송혜교님의 메세지 내용 69",
+        "font": "Pretendard",
+        "createdAt": "2023-04-09T12:19:23Z"
+      }
+    ],
+    "reactionCount": 33,
+    "topReactions": [
+      {
+        "id": 78114,
+        "emoji": "😁",
+        "count": 5
+      },
+      {
+        "id": 46240,
+        "emoji": "👍",
+        "count": 10
+      },
+      {
+        "id": 3995,
+        "emoji": "❤️",
+        "count": 7
+      },
+      {
+        "id": 47582,
+        "emoji": "👍",
+        "count": 11
+      }
+    ]
+  },
+  {
+    "id": 35155,
+    "name": "박서준",
+    "backgroundColor": "green",
+    "backgroundImageURL": null,
+    "createdAt": "2023-05-11T22:06:17Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 34211,
+        "recipientId": 35155,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/477/200/200",
+        "relationship": "지인",
+        "content": "전지현님의 메세지 내용 43",
+        "font": "Noto Sans",
+        "createdAt": "2024-01-05T06:58:56Z"
+      },
+      {
+        "id": 60206,
+        "recipientId": 35155,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/343/200/200",
+        "relationship": "친구",
+        "content": "최민수님의 메세지 내용 54",
+        "font": "Roboto",
+        "createdAt": "2023-03-30T16:06:27Z"
+      },
+      {
+        "id": 88132,
+        "recipientId": 35155,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/325/200/200",
+        "relationship": "동료",
+        "content": "정우성님의 메세지 내용 68",
+        "font": "Noto Sans",
+        "createdAt": "2023-08-09T19:25:45Z"
+      }
+    ],
+    "reactionCount": 61,
+    "topReactions": [
+      {
+        "id": 58872,
+        "emoji": "🥹",
+        "count": 13
+      }
+    ]
+  },
+  {
+    "id": 97436,
+    "name": "정우성",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/97436/600/400",
+    "createdAt": "2023-10-03T12:44:17Z",
+    "messageCount": 7,
+    "recentMessages": [
+      {
+        "id": 34424,
+        "recipientId": 97436,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/141/200/200",
+        "relationship": "지인",
+        "content": "이병헌님의 메세지 내용 6",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-06-01T12:35:35Z"
+      },
+      {
+        "id": 41272,
+        "recipientId": 97436,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/162/200/200",
+        "relationship": "가족",
+        "content": "한지민님의 메세지 내용 19",
+        "font": "Roboto",
+        "createdAt": "2023-05-07T04:01:58Z"
+      },
+      {
+        "id": 36494,
+        "recipientId": 97436,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/307/200/200",
+        "relationship": "친구",
+        "content": "박서준님의 메세지 내용 71",
+        "font": "Noto Sans",
+        "createdAt": "2023-07-14T08:50:29Z"
+      }
+    ],
+    "reactionCount": 61,
+    "topReactions": [
+      {
+        "id": 34505,
+        "emoji": "😀",
+        "count": 2
+      },
+      {
+        "id": 97779,
+        "emoji": "😁",
+        "count": 14
+      },
+      {
+        "id": 64296,
+        "emoji": "🥹",
+        "count": 17
+      }
+    ]
+  },
+  {
+    "id": 22932,
+    "name": "이병헌",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/22932/600/400",
+    "createdAt": "2023-12-21T05:29:02Z",
+    "messageCount": 1,
+    "recentMessages": [
+      {
+        "id": 5965,
+        "recipientId": 22932,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/368/200/200",
+        "relationship": "동료",
+        "content": "김하은님의 메세지 내용 41",
+        "font": "Roboto",
+        "createdAt": "2023-10-30T21:49:17Z"
+      }
+    ],
+    "reactionCount": 54,
+    "topReactions": [
+      {
+        "id": 80894,
+        "emoji": "👍",
+        "count": 6
+      }
+    ]
+  },
+  {
+    "id": 93316,
+    "name": "전지현",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-09-26T09:48:47Z",
+    "messageCount": 7,
+    "recentMessages": [
+      {
+        "id": 15981,
+        "recipientId": 93316,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/29/200/200",
+        "relationship": "동료",
+        "content": "송혜교님의 메세지 내용 23",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-07-01T10:41:23Z"
+      },
+      {
+        "id": 88647,
+        "recipientId": 93316,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/391/200/200",
+        "relationship": "가족",
+        "content": "이영준님의 메세지 내용 91",
+        "font": "Pretendard",
+        "createdAt": "2023-09-23T14:40:50Z"
+      },
+      {
+        "id": 36796,
+        "recipientId": 93316,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/485/200/200",
+        "relationship": "지인",
+        "content": "송혜교님의 메세지 내용 69",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-08-22T23:41:19Z"
+      }
+    ],
+    "reactionCount": 67,
+    "topReactions": [
+      {
+        "id": 20683,
+        "emoji": "😁",
+        "count": 7
+      },
+      {
+        "id": 55812,
+        "emoji": "❤️",
+        "count": 8
+      }
+    ]
+  },
+  {
+    "id": 25223,
+    "name": "전지현",
+    "backgroundColor": "blue",
+    "backgroundImageURL": null,
+    "createdAt": "2023-12-10T04:25:18Z",
+    "messageCount": 5,
+    "recentMessages": [
+      {
+        "id": 55898,
+        "recipientId": 25223,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/377/200/200",
+        "relationship": "동료",
+        "content": "이영준님의 메세지 내용 97",
+        "font": "Pretendard",
+        "createdAt": "2023-03-28T00:32:15Z"
+      },
+      {
+        "id": 28874,
+        "recipientId": 25223,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/338/200/200",
+        "relationship": "동료",
+        "content": "최민수님의 메세지 내용 71",
+        "font": "Roboto",
+        "createdAt": "2023-08-06T08:16:58Z"
+      },
+      {
+        "id": 21132,
+        "recipientId": 25223,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/259/200/200",
+        "relationship": "동료",
+        "content": "김하은님의 메세지 내용 53",
+        "font": "Noto Sans",
+        "createdAt": "2024-02-01T12:33:31Z"
+      }
+    ],
+    "reactionCount": 29,
+    "topReactions": [
+      {
+        "id": 60975,
+        "emoji": "🎉",
+        "count": 16
+      },
+      {
+        "id": 94228,
+        "emoji": "🎉",
+        "count": 12
+      }
+    ]
+  },
+  {
+    "id": 2194,
+    "name": "송혜교",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2023-10-16T00:02:43Z",
+    "messageCount": 9,
+    "recentMessages": [
+      {
+        "id": 97432,
+        "recipientId": 2194,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/140/200/200",
+        "relationship": "가족",
+        "content": "전지현님의 메세지 내용 42",
+        "font": "Pretendard",
+        "createdAt": "2023-02-14T20:58:12Z"
+      },
+      {
+        "id": 57885,
+        "recipientId": 2194,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/496/200/200",
+        "relationship": "가족",
+        "content": "최민수님의 메세지 내용 39",
+        "font": "Roboto",
+        "createdAt": "2023-10-19T16:47:29Z"
+      },
+      {
+        "id": 88963,
+        "recipientId": 2194,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/317/200/200",
+        "relationship": "가족",
+        "content": "이병헌님의 메세지 내용 81",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-03-12T08:38:10Z"
+      }
+    ],
+    "reactionCount": 32,
+    "topReactions": [
+      {
+        "id": 60382,
+        "emoji": "🎉",
+        "count": 14
+      },
+      {
+        "id": 35188,
+        "emoji": "😁",
+        "count": 16
+      },
+      {
+        "id": 36631,
+        "emoji": "😁",
+        "count": 7
+      },
+      {
+        "id": 42371,
+        "emoji": "❤️",
+        "count": 9
+      },
+      {
+        "id": 49401,
+        "emoji": "🥹",
+        "count": 14
+      },
+      {
+        "id": 62636,
+        "emoji": "😀",
+        "count": 4
+      }
+    ]
+  },
+  {
+    "id": 93426,
+    "name": "박서준",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2023-10-25T18:47:40Z",
+    "messageCount": 10,
+    "recentMessages": [
+      {
+        "id": 59310,
+        "recipientId": 93426,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/148/200/200",
+        "relationship": "친구",
+        "content": "정우성님의 메세지 내용 64",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-12-24T10:04:46Z"
+      },
+      {
+        "id": 91544,
+        "recipientId": 93426,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/153/200/200",
+        "relationship": "동료",
+        "content": "김하은님의 메세지 내용 79",
+        "font": "Noto Sans",
+        "createdAt": "2023-08-13T10:48:12Z"
+      },
+      {
+        "id": 56708,
+        "recipientId": 93426,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/55/200/200",
+        "relationship": "친구",
+        "content": "현빈님의 메세지 내용 32",
+        "font": "Noto Sans",
+        "createdAt": "2023-01-27T22:18:54Z"
+      }
+    ],
+    "reactionCount": 3,
+    "topReactions": [
+      {
+        "id": 75158,
+        "emoji": "😁",
+        "count": 16
+      },
+      {
+        "id": 91157,
+        "emoji": "👍",
+        "count": 1
+      },
+      {
+        "id": 62992,
+        "emoji": "👍",
+        "count": 5
+      },
+      {
+        "id": 36793,
+        "emoji": "😀",
+        "count": 11
+      },
+      {
+        "id": 47139,
+        "emoji": "👍",
+        "count": 18
+      }
+    ]
+  },
+  {
+    "id": 6785,
+    "name": "현빈",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/6785/600/400",
+    "createdAt": "2023-08-05T10:49:34Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 96256,
+        "recipientId": 6785,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/487/200/200",
+        "relationship": "친구",
+        "content": "한지민님의 메세지 내용 14",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-08-05T11:24:48Z"
+      },
+      {
+        "id": 95988,
+        "recipientId": 6785,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/123/200/200",
+        "relationship": "동료",
+        "content": "현빈님의 메세지 내용 78",
+        "font": "Pretendard",
+        "createdAt": "2023-05-16T00:54:03Z"
+      },
+      {
+        "id": 85410,
+        "recipientId": 6785,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/85/200/200",
+        "relationship": "동료",
+        "content": "한지민님의 메세지 내용 45",
+        "font": "Roboto",
+        "createdAt": "2023-09-22T09:06:14Z"
+      }
+    ],
+    "reactionCount": 18,
+    "topReactions": [
+      {
+        "id": 88345,
+        "emoji": "😀",
+        "count": 17
+      }
+    ]
+  },
+  {
+    "id": 70576,
+    "name": "정우성",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2024-01-24T03:10:15Z",
+    "messageCount": 1,
+    "recentMessages": [
+      {
+        "id": 5439,
+        "recipientId": 70576,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/172/200/200",
+        "relationship": "지인",
+        "content": "최민수님의 메세지 내용 41",
+        "font": "Roboto",
+        "createdAt": "2023-04-08T06:16:02Z"
+      }
+    ],
+    "reactionCount": 86,
+    "topReactions": [
+      {
+        "id": 61646,
+        "emoji": "😁",
+        "count": 6
+      },
+      {
+        "id": 36266,
+        "emoji": "🎉",
+        "count": 11
+      },
+      {
+        "id": 19739,
+        "emoji": "🎉",
+        "count": 19
+      },
+      {
+        "id": 49081,
+        "emoji": "🎉",
+        "count": 7
+      },
+      {
+        "id": 60907,
+        "emoji": "👍",
+        "count": 11
+      },
+      {
+        "id": 82566,
+        "emoji": "❤️",
+        "count": 14
+      }
+    ]
+  },
+  {
+    "id": 45901,
+    "name": "이병헌",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2023-06-14T15:34:31Z",
+    "messageCount": 10,
+    "recentMessages": [
+      {
+        "id": 38672,
+        "recipientId": 45901,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/444/200/200",
+        "relationship": "동료",
+        "content": "이영준님의 메세지 내용 57",
+        "font": "Pretendard",
+        "createdAt": "2023-08-25T13:09:41Z"
+      },
+      {
+        "id": 36570,
+        "recipientId": 45901,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/26/200/200",
+        "relationship": "지인",
+        "content": "전지현님의 메세지 내용 24",
+        "font": "Noto Sans",
+        "createdAt": "2023-08-23T03:39:28Z"
+      },
+      {
+        "id": 62649,
+        "recipientId": 45901,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/332/200/200",
+        "relationship": "가족",
+        "content": "이영준님의 메세지 내용 79",
+        "font": "Noto Sans",
+        "createdAt": "2023-01-07T13:25:26Z"
+      }
+    ],
+    "reactionCount": 15,
+    "topReactions": [
+      {
+        "id": 32010,
+        "emoji": "❤️",
+        "count": 20
+      },
+      {
+        "id": 25614,
+        "emoji": "❤️",
+        "count": 18
+      },
+      {
+        "id": 44236,
+        "emoji": "😁",
+        "count": 5
+      },
+      {
+        "id": 26955,
+        "emoji": "❤️",
+        "count": 12
+      },
+      {
+        "id": 68249,
+        "emoji": "😁",
+        "count": 9
+      }
+    ]
+  },
+  {
+    "id": 11943,
+    "name": "한지민",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-12-25T19:30:42Z",
+    "messageCount": 1,
+    "recentMessages": [
+      {
+        "id": 48559,
+        "recipientId": 11943,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/96/200/200",
+        "relationship": "지인",
+        "content": "정우성님의 메세지 내용 96",
+        "font": "Pretendard",
+        "createdAt": "2023-12-20T03:53:10Z"
+      }
+    ],
+    "reactionCount": 17,
+    "topReactions": [
+      {
+        "id": 38691,
+        "emoji": "🎉",
+        "count": 14
+      },
+      {
+        "id": 74561,
+        "emoji": "😁",
+        "count": 16
+      },
+      {
+        "id": 67482,
+        "emoji": "🥹",
+        "count": 11
+      },
+      {
+        "id": 77948,
+        "emoji": "😀",
+        "count": 5
+      }
+    ]
+  },
+  {
+    "id": 72748,
+    "name": "전지현",
+    "backgroundColor": "blue",
+    "backgroundImageURL": null,
+    "createdAt": "2024-01-18T06:23:22Z",
+    "messageCount": 2,
+    "recentMessages": [
+      {
+        "id": 70819,
+        "recipientId": 72748,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/178/200/200",
+        "relationship": "동료",
+        "content": "현빈님의 메세지 내용 32",
+        "font": "Pretendard",
+        "createdAt": "2023-11-07T20:19:02Z"
+      },
+      {
+        "id": 26784,
+        "recipientId": 72748,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/400/200/200",
+        "relationship": "친구",
+        "content": "김하은님의 메세지 내용 61",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-10-23T08:44:07Z"
+      }
+    ],
+    "reactionCount": 36,
+    "topReactions": [
+      {
+        "id": 41246,
+        "emoji": "😀",
+        "count": 3
+      },
+      {
+        "id": 91855,
+        "emoji": "❤️",
+        "count": 17
+      },
+      {
+        "id": 88660,
+        "emoji": "🎉",
+        "count": 1
+      },
+      {
+        "id": 98907,
+        "emoji": "❤️",
+        "count": 15
+      }
+    ]
+  },
+  {
+    "id": 84532,
+    "name": "김하은",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2023-11-26T12:07:49Z",
+    "messageCount": 10,
+    "recentMessages": [
+      {
+        "id": 99518,
+        "recipientId": 84532,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/2/200/200",
+        "relationship": "가족",
+        "content": "이병헌님의 메세지 내용 83",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-07-12T22:08:05Z"
+      },
+      {
+        "id": 26554,
+        "recipientId": 84532,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/411/200/200",
+        "relationship": "가족",
+        "content": "정우성님의 메세지 내용 100",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-12-14T17:02:19Z"
+      },
+      {
+        "id": 70782,
+        "recipientId": 84532,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/179/200/200",
+        "relationship": "친구",
+        "content": "김하은님의 메세지 내용 92",
+        "font": "Pretendard",
+        "createdAt": "2023-04-05T09:48:12Z"
+      }
+    ],
+    "reactionCount": 27,
+    "topReactions": [
+      {
+        "id": 24529,
+        "emoji": "🥹",
+        "count": 15
+      },
+      {
+        "id": 72262,
+        "emoji": "😀",
+        "count": 20
+      },
+      {
+        "id": 85359,
+        "emoji": "🎉",
+        "count": 16
+      }
+    ]
+  },
+  {
+    "id": 85839,
+    "name": "최민수",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/85839/600/400",
+    "createdAt": "2023-12-24T00:08:48Z",
+    "messageCount": 6,
+    "recentMessages": [
+      {
+        "id": 30831,
+        "recipientId": 85839,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/384/200/200",
+        "relationship": "지인",
+        "content": "송혜교님의 메세지 내용 43",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-09-07T15:08:29Z"
+      },
+      {
+        "id": 12285,
+        "recipientId": 85839,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/85/200/200",
+        "relationship": "친구",
+        "content": "현빈님의 메세지 내용 3",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-04-02T09:00:54Z"
+      },
+      {
+        "id": 72173,
+        "recipientId": 85839,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/137/200/200",
+        "relationship": "동료",
+        "content": "이병헌님의 메세지 내용 84",
+        "font": "Pretendard",
+        "createdAt": "2023-04-01T12:40:19Z"
+      }
+    ],
+    "reactionCount": 77,
+    "topReactions": [
+      {
+        "id": 89993,
+        "emoji": "❤️",
+        "count": 5
+      },
+      {
+        "id": 92268,
+        "emoji": "👍",
+        "count": 18
+      },
+      {
+        "id": 77791,
+        "emoji": "🎉",
+        "count": 15
+      },
+      {
+        "id": 34959,
+        "emoji": "🥹",
+        "count": 11
+      },
+      {
+        "id": 7685,
+        "emoji": "😀",
+        "count": 10
+      },
+      {
+        "id": 34844,
+        "emoji": "👍",
+        "count": 14
+      }
+    ]
+  },
+  {
+    "id": 34462,
+    "name": "최민수",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/34462/600/400",
+    "createdAt": "2023-05-09T05:20:10Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 94727,
+        "recipientId": 34462,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/495/200/200",
+        "relationship": "동료",
+        "content": "최민수님의 메세지 내용 1",
+        "font": "Roboto",
+        "createdAt": "2024-01-27T04:45:27Z"
+      },
+      {
+        "id": 65061,
+        "recipientId": 34462,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/477/200/200",
+        "relationship": "친구",
+        "content": "김하은님의 메세지 내용 64",
+        "font": "Roboto",
+        "createdAt": "2023-02-21T19:08:42Z"
+      },
+      {
+        "id": 75109,
+        "recipientId": 34462,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/149/200/200",
+        "relationship": "지인",
+        "content": "최민수님의 메세지 내용 38",
+        "font": "Roboto",
+        "createdAt": "2023-05-12T08:59:51Z"
+      }
+    ],
+    "reactionCount": 18,
+    "topReactions": [
+      {
+        "id": 39441,
+        "emoji": "👍",
+        "count": 16
+      },
+      {
+        "id": 89350,
+        "emoji": "🥹",
+        "count": 1
+      }
+    ]
+  },
+  {
+    "id": 76172,
+    "name": "박서준",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/76172/600/400",
+    "createdAt": "2023-12-30T15:01:40Z",
+    "messageCount": 10,
+    "recentMessages": [
+      {
+        "id": 28913,
+        "recipientId": 76172,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/499/200/200",
+        "relationship": "동료",
+        "content": "이영준님의 메세지 내용 85",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-01-06T21:55:19Z"
+      },
+      {
+        "id": 20559,
+        "recipientId": 76172,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/315/200/200",
+        "relationship": "친구",
+        "content": "이병헌님의 메세지 내용 53",
+        "font": "Roboto",
+        "createdAt": "2023-07-06T05:06:42Z"
+      },
+      {
+        "id": 92696,
+        "recipientId": 76172,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/71/200/200",
+        "relationship": "친구",
+        "content": "한지민님의 메세지 내용 39",
+        "font": "Roboto",
+        "createdAt": "2023-12-04T21:02:50Z"
+      }
+    ],
+    "reactionCount": 55,
+    "topReactions": [
+      {
+        "id": 1687,
+        "emoji": "🥹",
+        "count": 15
+      }
+    ]
+  },
+  {
+    "id": 22270,
+    "name": "최민수",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-08-29T23:33:29Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 12379,
+        "recipientId": 22270,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/212/200/200",
+        "relationship": "동료",
+        "content": "현빈님의 메세지 내용 30",
+        "font": "Pretendard",
+        "createdAt": "2023-01-03T08:31:04Z"
+      },
+      {
+        "id": 16402,
+        "recipientId": 22270,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/354/200/200",
+        "relationship": "동료",
+        "content": "현빈님의 메세지 내용 34",
+        "font": "Noto Sans",
+        "createdAt": "2023-07-25T04:27:06Z"
+      },
+      {
+        "id": 379,
+        "recipientId": 22270,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/14/200/200",
+        "relationship": "친구",
+        "content": "박서준님의 메세지 내용 4",
+        "font": "Pretendard",
+        "createdAt": "2023-07-09T01:19:05Z"
+      }
+    ],
+    "reactionCount": 11,
+    "topReactions": [
+      {
+        "id": 3029,
+        "emoji": "👍",
+        "count": 13
+      },
+      {
+        "id": 76170,
+        "emoji": "👍",
+        "count": 15
+      },
+      {
+        "id": 96379,
+        "emoji": "😀",
+        "count": 13
+      },
+      {
+        "id": 89555,
+        "emoji": "😀",
+        "count": 16
+      },
+      {
+        "id": 39796,
+        "emoji": "❤️",
+        "count": 17
+      }
+    ]
+  },
+  {
+    "id": 525,
+    "name": "김하은",
+    "backgroundColor": "blue",
+    "backgroundImageURL": null,
+    "createdAt": "2024-01-23T15:35:52Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 42938,
+        "recipientId": 525,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/301/200/200",
+        "relationship": "가족",
+        "content": "송혜교님의 메세지 내용 29",
+        "font": "Roboto",
+        "createdAt": "2023-02-24T19:32:02Z"
+      },
+      {
+        "id": 26243,
+        "recipientId": 525,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/470/200/200",
+        "relationship": "친구",
+        "content": "이병헌님의 메세지 내용 36",
+        "font": "Noto Sans",
+        "createdAt": "2024-02-01T22:09:11Z"
+      },
+      {
+        "id": 87049,
+        "recipientId": 525,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/97/200/200",
+        "relationship": "가족",
+        "content": "최민수님의 메세지 내용 19",
+        "font": "Pretendard",
+        "createdAt": "2023-03-20T23:42:55Z"
+      }
+    ],
+    "reactionCount": 40,
+    "topReactions": [
+      {
+        "id": 92021,
+        "emoji": "❤️",
+        "count": 17
+      },
+      {
+        "id": 63448,
+        "emoji": "😀",
+        "count": 11
+      }
+    ]
+  },
+  {
+    "id": 21667,
+    "name": "박서준",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/21667/600/400",
+    "createdAt": "2023-09-14T10:29:13Z",
+    "messageCount": 1,
+    "recentMessages": [
+      {
+        "id": 68623,
+        "recipientId": 21667,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/272/200/200",
+        "relationship": "가족",
+        "content": "박서준님의 메세지 내용 34",
+        "font": "Pretendard",
+        "createdAt": "2023-04-14T02:05:32Z"
+      }
+    ],
+    "reactionCount": 2,
+    "topReactions": [
+      {
+        "id": 6976,
+        "emoji": "❤️",
+        "count": 1
+      }
+    ]
+  },
+  {
+    "id": 22425,
+    "name": "박서준",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/22425/600/400",
+    "createdAt": "2023-10-10T09:00:27Z",
+    "messageCount": 3,
+    "recentMessages": [
+      {
+        "id": 73839,
+        "recipientId": 22425,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/10/200/200",
+        "relationship": "가족",
+        "content": "송혜교님의 메세지 내용 77",
+        "font": "Pretendard",
+        "createdAt": "2023-12-14T00:57:33Z"
+      },
+      {
+        "id": 52414,
+        "recipientId": 22425,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/225/200/200",
+        "relationship": "동료",
+        "content": "박서준님의 메세지 내용 93",
+        "font": "Nanum Gothic",
+        "createdAt": "2024-01-13T15:32:28Z"
+      },
+      {
+        "id": 2179,
+        "recipientId": 22425,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/233/200/200",
+        "relationship": "지인",
+        "content": "김하은님의 메세지 내용 89",
+        "font": "Noto Sans",
+        "createdAt": "2023-12-12T17:43:00Z"
+      }
+    ],
+    "reactionCount": 28,
+    "topReactions": [
+      {
+        "id": 38379,
+        "emoji": "🥹",
+        "count": 3
+      }
+    ]
+  },
+  {
+    "id": 80244,
+    "name": "현빈",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/80244/600/400",
+    "createdAt": "2023-11-15T21:46:24Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 68208,
+        "recipientId": 80244,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/113/200/200",
+        "relationship": "가족",
+        "content": "김하은님의 메세지 내용 4",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-11-16T20:54:09Z"
+      },
+      {
+        "id": 71898,
+        "recipientId": 80244,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/466/200/200",
+        "relationship": "동료",
+        "content": "정우성님의 메세지 내용 20",
+        "font": "Roboto",
+        "createdAt": "2023-04-22T21:18:17Z"
+      },
+      {
+        "id": 70652,
+        "recipientId": 80244,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/169/200/200",
+        "relationship": "가족",
+        "content": "박서준님의 메세지 내용 38",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-08-27T22:00:41Z"
+      }
+    ],
+    "reactionCount": 54,
+    "topReactions": [
+      {
+        "id": 63000,
+        "emoji": "🎉",
+        "count": 12
+      }
+    ]
+  },
+  {
+    "id": 76854,
+    "name": "한지민",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/76854/600/400",
+    "createdAt": "2023-05-13T20:54:53Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 8442,
+        "recipientId": 76854,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/391/200/200",
+        "relationship": "지인",
+        "content": "이병헌님의 메세지 내용 6",
+        "font": "Pretendard",
+        "createdAt": "2023-12-21T09:27:19Z"
+      },
+      {
+        "id": 78435,
+        "recipientId": 76854,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/478/200/200",
+        "relationship": "가족",
+        "content": "최민수님의 메세지 내용 90",
+        "font": "Noto Sans",
+        "createdAt": "2024-01-11T13:23:28Z"
+      },
+      {
+        "id": 51295,
+        "recipientId": 76854,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/470/200/200",
+        "relationship": "가족",
+        "content": "박서준님의 메세지 내용 25",
+        "font": "Roboto",
+        "createdAt": "2023-11-25T10:48:40Z"
+      }
+    ],
+    "reactionCount": 86,
+    "topReactions": [
+      {
+        "id": 27143,
+        "emoji": "🥹",
+        "count": 8
+      }
+    ]
+  },
+  {
+    "id": 50919,
+    "name": "이영준",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-04-06T15:13:00Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 3111,
+        "recipientId": 50919,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/384/200/200",
+        "relationship": "친구",
+        "content": "이병헌님의 메세지 내용 80",
+        "font": "Pretendard",
+        "createdAt": "2023-08-12T11:51:00Z"
+      },
+      {
+        "id": 38535,
+        "recipientId": 50919,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/170/200/200",
+        "relationship": "동료",
+        "content": "정우성님의 메세지 내용 59",
+        "font": "Roboto",
+        "createdAt": "2024-01-21T06:32:43Z"
+      },
+      {
+        "id": 80939,
+        "recipientId": 50919,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/67/200/200",
+        "relationship": "친구",
+        "content": "송혜교님의 메세지 내용 8",
+        "font": "Noto Sans",
+        "createdAt": "2023-09-23T14:56:17Z"
+      }
+    ],
+    "reactionCount": 76,
+    "topReactions": [
+      {
+        "id": 89101,
+        "emoji": "👍",
+        "count": 12
+      },
+      {
+        "id": 60242,
+        "emoji": "😁",
+        "count": 17
+      },
+      {
+        "id": 97519,
+        "emoji": "🎉",
+        "count": 11
+      },
+      {
+        "id": 65104,
+        "emoji": "❤️",
+        "count": 7
+      }
+    ]
+  },
+  {
+    "id": 44601,
+    "name": "전지현",
+    "backgroundColor": "green",
+    "backgroundImageURL": null,
+    "createdAt": "2023-01-29T11:53:40Z",
+    "messageCount": 7,
+    "recentMessages": [
+      {
+        "id": 90217,
+        "recipientId": 44601,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/445/200/200",
+        "relationship": "동료",
+        "content": "현빈님의 메세지 내용 14",
+        "font": "Roboto",
+        "createdAt": "2023-09-25T19:48:08Z"
+      },
+      {
+        "id": 73220,
+        "recipientId": 44601,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/32/200/200",
+        "relationship": "가족",
+        "content": "송혜교님의 메세지 내용 73",
+        "font": "Roboto",
+        "createdAt": "2023-06-09T10:53:20Z"
+      },
+      {
+        "id": 24251,
+        "recipientId": 44601,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/256/200/200",
+        "relationship": "지인",
+        "content": "전지현님의 메세지 내용 98",
+        "font": "Noto Sans",
+        "createdAt": "2023-10-12T16:19:37Z"
+      }
+    ],
+    "reactionCount": 90,
+    "topReactions": [
+      {
+        "id": 95691,
+        "emoji": "🎉",
+        "count": 3
+      },
+      {
+        "id": 89483,
+        "emoji": "😁",
+        "count": 2
+      },
+      {
+        "id": 56468,
+        "emoji": "🎉",
+        "count": 13
+      }
+    ]
+  },
+  {
+    "id": 37974,
+    "name": "정우성",
+    "backgroundColor": "blue",
+    "backgroundImageURL": null,
+    "createdAt": "2023-12-26T20:53:27Z",
+    "messageCount": 1,
+    "recentMessages": [
+      {
+        "id": 43644,
+        "recipientId": 37974,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/215/200/200",
+        "relationship": "지인",
+        "content": "송혜교님의 메세지 내용 26",
+        "font": "Roboto",
+        "createdAt": "2023-10-29T16:46:20Z"
+      }
+    ],
+    "reactionCount": 88,
+    "topReactions": [
+      {
+        "id": 72401,
+        "emoji": "❤️",
+        "count": 3
+      },
+      {
+        "id": 5640,
+        "emoji": "❤️",
+        "count": 5
+      }
+    ]
+  },
+  {
+    "id": 65650,
+    "name": "현빈",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-12-29T01:51:13Z",
+    "messageCount": 3,
+    "recentMessages": [
+      {
+        "id": 20882,
+        "recipientId": 65650,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/342/200/200",
+        "relationship": "동료",
+        "content": "한지민님의 메세지 내용 76",
+        "font": "Roboto",
+        "createdAt": "2023-01-13T21:59:32Z"
+      },
+      {
+        "id": 79855,
+        "recipientId": 65650,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/42/200/200",
+        "relationship": "동료",
+        "content": "정우성님의 메세지 내용 71",
+        "font": "Roboto",
+        "createdAt": "2023-05-13T19:20:45Z"
+      },
+      {
+        "id": 38337,
+        "recipientId": 65650,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/459/200/200",
+        "relationship": "가족",
+        "content": "송혜교님의 메세지 내용 83",
+        "font": "Roboto",
+        "createdAt": "2023-03-02T21:24:55Z"
+      }
+    ],
+    "reactionCount": 17,
+    "topReactions": [
+      {
+        "id": 91559,
+        "emoji": "🥹",
+        "count": 3
+      },
+      {
+        "id": 56771,
+        "emoji": "🎉",
+        "count": 3
+      },
+      {
+        "id": 15952,
+        "emoji": "❤️",
+        "count": 18
+      },
+      {
+        "id": 90450,
+        "emoji": "👍",
+        "count": 15
+      },
+      {
+        "id": 52341,
+        "emoji": "😀",
+        "count": 14
+      }
+    ]
+  },
+  {
+    "id": 41386,
+    "name": "김하은",
+    "backgroundColor": "blue",
+    "backgroundImageURL": null,
+    "createdAt": "2023-01-01T07:46:06Z",
+    "messageCount": 6,
+    "recentMessages": [
+      {
+        "id": 89635,
+        "recipientId": 41386,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/192/200/200",
+        "relationship": "가족",
+        "content": "전지현님의 메세지 내용 44",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-08-29T17:09:14Z"
+      },
+      {
+        "id": 89440,
+        "recipientId": 41386,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/401/200/200",
+        "relationship": "지인",
+        "content": "박서준님의 메세지 내용 35",
+        "font": "Noto Sans",
+        "createdAt": "2023-12-31T16:32:30Z"
+      },
+      {
+        "id": 54885,
+        "recipientId": 41386,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/97/200/200",
+        "relationship": "가족",
+        "content": "전지현님의 메세지 내용 43",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-05-05T08:14:34Z"
+      }
+    ],
+    "reactionCount": 78,
+    "topReactions": [
+      {
+        "id": 65046,
+        "emoji": "🎉",
+        "count": 12
+      },
+      {
+        "id": 94282,
+        "emoji": "😀",
+        "count": 15
+      },
+      {
+        "id": 87051,
+        "emoji": "🎉",
+        "count": 12
+      },
+      {
+        "id": 76472,
+        "emoji": "😁",
+        "count": 12
+      },
+      {
+        "id": 43401,
+        "emoji": "🥹",
+        "count": 1
+      }
+    ]
+  },
+  {
+    "id": 5465,
+    "name": "이병헌",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-01-10T18:10:25Z",
+    "messageCount": 10,
+    "recentMessages": [
+      {
+        "id": 28514,
+        "recipientId": 5465,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/388/200/200",
+        "relationship": "가족",
+        "content": "정우성님의 메세지 내용 77",
+        "font": "Pretendard",
+        "createdAt": "2023-10-28T19:29:15Z"
+      },
+      {
+        "id": 69038,
+        "recipientId": 5465,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/412/200/200",
+        "relationship": "지인",
+        "content": "전지현님의 메세지 내용 88",
+        "font": "Noto Sans",
+        "createdAt": "2023-06-16T07:01:10Z"
+      },
+      {
+        "id": 24211,
+        "recipientId": 5465,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/89/200/200",
+        "relationship": "지인",
+        "content": "한지민님의 메세지 내용 16",
+        "font": "Pretendard",
+        "createdAt": "2023-01-05T16:10:00Z"
+      }
+    ],
+    "reactionCount": 25,
+    "topReactions": [
+      {
+        "id": 59656,
+        "emoji": "😁",
+        "count": 15
+      },
+      {
+        "id": 91642,
+        "emoji": "👍",
+        "count": 6
+      },
+      {
+        "id": 63844,
+        "emoji": "🎉",
+        "count": 9
+      },
+      {
+        "id": 38254,
+        "emoji": "🎉",
+        "count": 13
+      },
+      {
+        "id": 80222,
+        "emoji": "🎉",
+        "count": 3
+      },
+      {
+        "id": 76177,
+        "emoji": "🎉",
+        "count": 10
+      }
+    ]
+  },
+  {
+    "id": 51890,
+    "name": "이영준",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-10-30T15:21:41Z",
+    "messageCount": 1,
+    "recentMessages": [
+      {
+        "id": 35764,
+        "recipientId": 51890,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/169/200/200",
+        "relationship": "가족",
+        "content": "한지민님의 메세지 내용 43",
+        "font": "Nanum Gothic",
+        "createdAt": "2024-01-14T11:24:57Z"
+      }
+    ],
+    "reactionCount": 60,
+    "topReactions": [
+      {
+        "id": 21526,
+        "emoji": "❤️",
+        "count": 9
+      },
+      {
+        "id": 89624,
+        "emoji": "😁",
+        "count": 9
+      },
+      {
+        "id": 92331,
+        "emoji": "🎉",
+        "count": 17
+      },
+      {
+        "id": 56922,
+        "emoji": "🎉",
+        "count": 12
+      }
+    ]
+  },
+  {
+    "id": 3937,
+    "name": "김하은",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-08-26T13:39:55Z",
+    "messageCount": 7,
+    "recentMessages": [
+      {
+        "id": 16211,
+        "recipientId": 3937,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/329/200/200",
+        "relationship": "동료",
+        "content": "김하은님의 메세지 내용 72",
+        "font": "Noto Sans",
+        "createdAt": "2023-09-13T00:33:13Z"
+      },
+      {
+        "id": 60479,
+        "recipientId": 3937,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/165/200/200",
+        "relationship": "동료",
+        "content": "김하은님의 메세지 내용 34",
+        "font": "Noto Sans",
+        "createdAt": "2023-12-21T21:06:23Z"
+      },
+      {
+        "id": 77695,
+        "recipientId": 3937,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/390/200/200",
+        "relationship": "가족",
+        "content": "최민수님의 메세지 내용 62",
+        "font": "Pretendard",
+        "createdAt": "2023-07-27T13:22:46Z"
+      }
+    ],
+    "reactionCount": 3,
+    "topReactions": [
+      {
+        "id": 75083,
+        "emoji": "🎉",
+        "count": 3
+      },
+      {
+        "id": 99458,
+        "emoji": "👍",
+        "count": 8
+      },
+      {
+        "id": 58435,
+        "emoji": "🥹",
+        "count": 9
+      },
+      {
+        "id": 35549,
+        "emoji": "😀",
+        "count": 12
+      },
+      {
+        "id": 89316,
+        "emoji": "🥹",
+        "count": 12
+      },
+      {
+        "id": 92464,
+        "emoji": "😀",
+        "count": 12
+      }
+    ]
+  },
+  {
+    "id": 15425,
+    "name": "최민수",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/15425/600/400",
+    "createdAt": "2024-01-29T12:40:23Z",
+    "messageCount": 6,
+    "recentMessages": [
+      {
+        "id": 40648,
+        "recipientId": 15425,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/236/200/200",
+        "relationship": "동료",
+        "content": "정우성님의 메세지 내용 50",
+        "font": "Roboto",
+        "createdAt": "2023-01-19T11:20:15Z"
+      },
+      {
+        "id": 4968,
+        "recipientId": 15425,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/433/200/200",
+        "relationship": "동료",
+        "content": "전지현님의 메세지 내용 47",
+        "font": "Roboto",
+        "createdAt": "2023-11-15T17:20:59Z"
+      },
+      {
+        "id": 38363,
+        "recipientId": 15425,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/246/200/200",
+        "relationship": "친구",
+        "content": "정우성님의 메세지 내용 72",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-03-18T16:01:25Z"
+      }
+    ],
+    "reactionCount": 50,
+    "topReactions": [
+      {
+        "id": 16722,
+        "emoji": "🎉",
+        "count": 11
+      },
+      {
+        "id": 59575,
+        "emoji": "👍",
+        "count": 9
+      },
+      {
+        "id": 92248,
+        "emoji": "😁",
+        "count": 2
+      }
+    ]
+  },
+  {
+    "id": 5267,
+    "name": "한지민",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/5267/600/400",
+    "createdAt": "2023-08-21T12:37:58Z",
+    "messageCount": 9,
+    "recentMessages": [
+      {
+        "id": 56322,
+        "recipientId": 5267,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/270/200/200",
+        "relationship": "동료",
+        "content": "현빈님의 메세지 내용 87",
+        "font": "Noto Sans",
+        "createdAt": "2023-12-15T10:09:08Z"
+      },
+      {
+        "id": 59649,
+        "recipientId": 5267,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/283/200/200",
+        "relationship": "지인",
+        "content": "현빈님의 메세지 내용 5",
+        "font": "Roboto",
+        "createdAt": "2023-09-27T15:11:17Z"
+      },
+      {
+        "id": 30468,
+        "recipientId": 5267,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/241/200/200",
+        "relationship": "지인",
+        "content": "최민수님의 메세지 내용 90",
+        "font": "Roboto",
+        "createdAt": "2023-02-21T22:25:32Z"
+      }
+    ],
+    "reactionCount": 19,
+    "topReactions": [
+      {
+        "id": 40145,
+        "emoji": "😁",
+        "count": 19
+      },
+      {
+        "id": 85434,
+        "emoji": "❤️",
+        "count": 4
+      },
+      {
+        "id": 12101,
+        "emoji": "😁",
+        "count": 14
+      },
+      {
+        "id": 81287,
+        "emoji": "😁",
+        "count": 16
+      },
+      {
+        "id": 4370,
+        "emoji": "❤️",
+        "count": 6
+      },
+      {
+        "id": 37361,
+        "emoji": "😀",
+        "count": 3
+      }
+    ]
+  },
+  {
+    "id": 76905,
+    "name": "한지민",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/76905/600/400",
+    "createdAt": "2023-07-25T12:26:52Z",
+    "messageCount": 6,
+    "recentMessages": [
+      {
+        "id": 71574,
+        "recipientId": 76905,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/299/200/200",
+        "relationship": "지인",
+        "content": "송혜교님의 메세지 내용 65",
+        "font": "Pretendard",
+        "createdAt": "2023-12-25T00:11:15Z"
+      },
+      {
+        "id": 881,
+        "recipientId": 76905,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/225/200/200",
+        "relationship": "지인",
+        "content": "송혜교님의 메세지 내용 55",
+        "font": "Pretendard",
+        "createdAt": "2023-10-08T00:53:44Z"
+      },
+      {
+        "id": 3393,
+        "recipientId": 76905,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/140/200/200",
+        "relationship": "지인",
+        "content": "전지현님의 메세지 내용 36",
+        "font": "Noto Sans",
+        "createdAt": "2023-11-01T14:38:31Z"
+      }
+    ],
+    "reactionCount": 89,
+    "topReactions": [
+      {
+        "id": 68890,
+        "emoji": "😁",
+        "count": 8
+      },
+      {
+        "id": 36484,
+        "emoji": "🥹",
+        "count": 11
+      }
+    ]
+  },
+  {
+    "id": 90385,
+    "name": "송혜교",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/90385/600/400",
+    "createdAt": "2023-08-06T10:39:41Z",
+    "messageCount": 1,
+    "recentMessages": [
+      {
+        "id": 66552,
+        "recipientId": 90385,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/498/200/200",
+        "relationship": "동료",
+        "content": "이병헌님의 메세지 내용 36",
+        "font": "Noto Sans",
+        "createdAt": "2023-10-17T11:54:41Z"
+      }
+    ],
+    "reactionCount": 73,
+    "topReactions": [
+      {
+        "id": 88512,
+        "emoji": "❤️",
+        "count": 4
+      },
+      {
+        "id": 33951,
+        "emoji": "🥹",
+        "count": 10
+      }
+    ]
+  },
+  {
+    "id": 83350,
+    "name": "박서준",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/83350/600/400",
+    "createdAt": "2024-01-11T21:50:53Z",
+    "messageCount": 2,
+    "recentMessages": [
+      {
+        "id": 85297,
+        "recipientId": 83350,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/454/200/200",
+        "relationship": "친구",
+        "content": "최민수님의 메세지 내용 81",
+        "font": "Roboto",
+        "createdAt": "2023-07-28T00:02:33Z"
+      },
+      {
+        "id": 78381,
+        "recipientId": 83350,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/293/200/200",
+        "relationship": "친구",
+        "content": "송혜교님의 메세지 내용 61",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-05-23T14:59:39Z"
+      }
+    ],
+    "reactionCount": 87,
+    "topReactions": [
+      {
+        "id": 7092,
+        "emoji": "🥹",
+        "count": 20
+      }
+    ]
+  },
+  {
+    "id": 82914,
+    "name": "이영준",
+    "backgroundColor": "blue",
+    "backgroundImageURL": null,
+    "createdAt": "2023-01-18T08:55:14Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 97740,
+        "recipientId": 82914,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/30/200/200",
+        "relationship": "가족",
+        "content": "한지민님의 메세지 내용 95",
+        "font": "Noto Sans",
+        "createdAt": "2023-05-17T12:57:29Z"
+      },
+      {
+        "id": 47854,
+        "recipientId": 82914,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/267/200/200",
+        "relationship": "동료",
+        "content": "송혜교님의 메세지 내용 91",
+        "font": "Roboto",
+        "createdAt": "2023-02-08T23:14:03Z"
+      },
+      {
+        "id": 93329,
+        "recipientId": 82914,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/468/200/200",
+        "relationship": "동료",
+        "content": "한지민님의 메세지 내용 86",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-04-12T17:20:58Z"
+      }
+    ],
+    "reactionCount": 48,
+    "topReactions": [
+      {
+        "id": 47934,
+        "emoji": "❤️",
+        "count": 7
+      },
+      {
+        "id": 38552,
+        "emoji": "🥹",
+        "count": 12
+      },
+      {
+        "id": 97573,
+        "emoji": "❤️",
+        "count": 17
+      },
+      {
+        "id": 90066,
+        "emoji": "👍",
+        "count": 17
+      },
+      {
+        "id": 75594,
+        "emoji": "👍",
+        "count": 5
+      },
+      {
+        "id": 80625,
+        "emoji": "🥹",
+        "count": 10
+      }
+    ]
+  },
+  {
+    "id": 39122,
+    "name": "현빈",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/39122/600/400",
+    "createdAt": "2024-01-28T01:36:34Z",
+    "messageCount": 10,
+    "recentMessages": [
+      {
+        "id": 59673,
+        "recipientId": 39122,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/467/200/200",
+        "relationship": "동료",
+        "content": "이병헌님의 메세지 내용 15",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-03-20T07:58:11Z"
+      },
+      {
+        "id": 30276,
+        "recipientId": 39122,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/111/200/200",
+        "relationship": "가족",
+        "content": "전지현님의 메세지 내용 19",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-01-11T05:07:07Z"
+      },
+      {
+        "id": 34351,
+        "recipientId": 39122,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/201/200/200",
+        "relationship": "친구",
+        "content": "전지현님의 메세지 내용 90",
+        "font": "Roboto",
+        "createdAt": "2023-03-09T04:25:04Z"
+      }
+    ],
+    "reactionCount": 54,
+    "topReactions": [
+      {
+        "id": 21238,
+        "emoji": "❤️",
+        "count": 7
+      },
+      {
+        "id": 36319,
+        "emoji": "🥹",
+        "count": 8
+      }
+    ]
+  },
+  {
+    "id": 36279,
+    "name": "최민수",
+    "backgroundColor": "green",
+    "backgroundImageURL": null,
+    "createdAt": "2023-04-06T20:33:22Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 12730,
+        "recipientId": 36279,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/410/200/200",
+        "relationship": "동료",
+        "content": "현빈님의 메세지 내용 15",
+        "font": "Noto Sans",
+        "createdAt": "2023-08-13T17:05:31Z"
+      },
+      {
+        "id": 64017,
+        "recipientId": 36279,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/1/200/200",
+        "relationship": "동료",
+        "content": "송혜교님의 메세지 내용 22",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-07-14T20:46:20Z"
+      },
+      {
+        "id": 87956,
+        "recipientId": 36279,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/362/200/200",
+        "relationship": "가족",
+        "content": "이병헌님의 메세지 내용 45",
+        "font": "Pretendard",
+        "createdAt": "2023-01-10T01:43:19Z"
+      }
+    ],
+    "reactionCount": 58,
+    "topReactions": [
+      {
+        "id": 37731,
+        "emoji": "🎉",
+        "count": 19
+      },
+      {
+        "id": 95128,
+        "emoji": "🥹",
+        "count": 12
+      },
+      {
+        "id": 65326,
+        "emoji": "🎉",
+        "count": 9
+      }
+    ]
+  },
+  {
+    "id": 75295,
+    "name": "정우성",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/75295/600/400",
+    "createdAt": "2023-06-12T15:45:08Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 87774,
+        "recipientId": 75295,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/376/200/200",
+        "relationship": "지인",
+        "content": "현빈님의 메세지 내용 49",
+        "font": "Roboto",
+        "createdAt": "2023-01-22T06:59:23Z"
+      },
+      {
+        "id": 46159,
+        "recipientId": 75295,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/478/200/200",
+        "relationship": "동료",
+        "content": "이영준님의 메세지 내용 57",
+        "font": "Noto Sans",
+        "createdAt": "2023-07-18T17:15:24Z"
+      },
+      {
+        "id": 34427,
+        "recipientId": 75295,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/371/200/200",
+        "relationship": "동료",
+        "content": "정우성님의 메세지 내용 46",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-09-30T13:38:37Z"
+      }
+    ],
+    "reactionCount": 11,
+    "topReactions": [
+      {
+        "id": 60036,
+        "emoji": "🎉",
+        "count": 20
+      },
+      {
+        "id": 66223,
+        "emoji": "😁",
+        "count": 5
+      },
+      {
+        "id": 57559,
+        "emoji": "❤️",
+        "count": 14
+      },
+      {
+        "id": 85462,
+        "emoji": "❤️",
+        "count": 18
+      },
+      {
+        "id": 78366,
+        "emoji": "❤️",
+        "count": 10
+      }
+    ]
+  },
+  {
+    "id": 53963,
+    "name": "이영준",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2023-04-10T05:19:05Z",
+    "messageCount": 6,
+    "recentMessages": [
+      {
+        "id": 8017,
+        "recipientId": 53963,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/176/200/200",
+        "relationship": "가족",
+        "content": "한지민님의 메세지 내용 62",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-08-08T16:57:27Z"
+      },
+      {
+        "id": 65904,
+        "recipientId": 53963,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/242/200/200",
+        "relationship": "가족",
+        "content": "한지민님의 메세지 내용 91",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-05-25T20:32:37Z"
+      },
+      {
+        "id": 38157,
+        "recipientId": 53963,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/241/200/200",
+        "relationship": "지인",
+        "content": "최민수님의 메세지 내용 33",
+        "font": "Pretendard",
+        "createdAt": "2023-02-22T19:17:47Z"
+      }
+    ],
+    "reactionCount": 1,
+    "topReactions": [
+      {
+        "id": 85067,
+        "emoji": "❤️",
+        "count": 19
+      },
+      {
+        "id": 23463,
+        "emoji": "🎉",
+        "count": 14
+      }
+    ]
+  },
+  {
+    "id": 48079,
+    "name": "현빈",
+    "backgroundColor": "blue",
+    "backgroundImageURL": null,
+    "createdAt": "2023-08-04T13:19:14Z",
+    "messageCount": 9,
+    "recentMessages": [
+      {
+        "id": 66088,
+        "recipientId": 48079,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/450/200/200",
+        "relationship": "지인",
+        "content": "최민수님의 메세지 내용 79",
+        "font": "Noto Sans",
+        "createdAt": "2023-03-02T15:36:09Z"
+      },
+      {
+        "id": 80363,
+        "recipientId": 48079,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/413/200/200",
+        "relationship": "동료",
+        "content": "한지민님의 메세지 내용 56",
+        "font": "Noto Sans",
+        "createdAt": "2023-07-22T12:40:41Z"
+      },
+      {
+        "id": 7160,
+        "recipientId": 48079,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/394/200/200",
+        "relationship": "친구",
+        "content": "전지현님의 메세지 내용 43",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-05-06T03:20:45Z"
+      }
+    ],
+    "reactionCount": 13,
+    "topReactions": [
+      {
+        "id": 47472,
+        "emoji": "🥹",
+        "count": 1
+      },
+      {
+        "id": 73490,
+        "emoji": "👍",
+        "count": 7
+      },
+      {
+        "id": 9397,
+        "emoji": "😁",
+        "count": 18
+      },
+      {
+        "id": 62463,
+        "emoji": "😀",
+        "count": 8
+      }
+    ]
+  },
+  {
+    "id": 2640,
+    "name": "정우성",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2023-10-09T05:47:27Z",
+    "messageCount": 10,
+    "recentMessages": [
+      {
+        "id": 23910,
+        "recipientId": 2640,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/181/200/200",
+        "relationship": "친구",
+        "content": "이영준님의 메세지 내용 99",
+        "font": "Roboto",
+        "createdAt": "2024-01-05T08:03:41Z"
+      },
+      {
+        "id": 60985,
+        "recipientId": 2640,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/440/200/200",
+        "relationship": "동료",
+        "content": "이병헌님의 메세지 내용 52",
+        "font": "Pretendard",
+        "createdAt": "2023-05-11T23:03:58Z"
+      },
+      {
+        "id": 32855,
+        "recipientId": 2640,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/29/200/200",
+        "relationship": "가족",
+        "content": "정우성님의 메세지 내용 76",
+        "font": "Roboto",
+        "createdAt": "2023-01-24T04:09:39Z"
+      }
+    ],
+    "reactionCount": 39,
+    "topReactions": [
+      {
+        "id": 68723,
+        "emoji": "😁",
+        "count": 10
+      }
+    ]
+  },
+  {
+    "id": 54287,
+    "name": "이영준",
+    "backgroundColor": "blue",
+    "backgroundImageURL": null,
+    "createdAt": "2024-01-12T17:22:52Z",
+    "messageCount": 2,
+    "recentMessages": [
+      {
+        "id": 79772,
+        "recipientId": 54287,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/25/200/200",
+        "relationship": "지인",
+        "content": "전지현님의 메세지 내용 20",
+        "font": "Pretendard",
+        "createdAt": "2023-06-06T00:54:01Z"
+      },
+      {
+        "id": 54858,
+        "recipientId": 54287,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/28/200/200",
+        "relationship": "지인",
+        "content": "현빈님의 메세지 내용 13",
+        "font": "Noto Sans",
+        "createdAt": "2024-01-30T02:08:36Z"
+      }
+    ],
+    "reactionCount": 59,
+    "topReactions": [
+      {
+        "id": 67796,
+        "emoji": "👍",
+        "count": 17
+      },
+      {
+        "id": 73312,
+        "emoji": "🎉",
+        "count": 14
+      },
+      {
+        "id": 69831,
+        "emoji": "❤️",
+        "count": 6
+      },
+      {
+        "id": 68250,
+        "emoji": "😁",
+        "count": 15
+      }
+    ]
+  },
+  {
+    "id": 51366,
+    "name": "이영준",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/51366/600/400",
+    "createdAt": "2023-09-29T07:35:31Z",
+    "messageCount": 7,
+    "recentMessages": [
+      {
+        "id": 92592,
+        "recipientId": 51366,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/301/200/200",
+        "relationship": "동료",
+        "content": "송혜교님의 메세지 내용 7",
+        "font": "Roboto",
+        "createdAt": "2023-02-08T19:54:33Z"
+      },
+      {
+        "id": 22441,
+        "recipientId": 51366,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/424/200/200",
+        "relationship": "가족",
+        "content": "한지민님의 메세지 내용 12",
+        "font": "Noto Sans",
+        "createdAt": "2023-03-22T19:53:29Z"
+      },
+      {
+        "id": 74021,
+        "recipientId": 51366,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/111/200/200",
+        "relationship": "친구",
+        "content": "현빈님의 메세지 내용 100",
+        "font": "Noto Sans",
+        "createdAt": "2023-09-03T16:40:11Z"
+      }
+    ],
+    "reactionCount": 3,
+    "topReactions": [
+      {
+        "id": 61747,
+        "emoji": "😁",
+        "count": 6
+      },
+      {
+        "id": 25034,
+        "emoji": "🥹",
+        "count": 7
+      }
+    ]
+  },
+  {
+    "id": 53790,
+    "name": "김하은",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/53790/600/400",
+    "createdAt": "2023-08-17T10:17:13Z",
+    "messageCount": 5,
+    "recentMessages": [
+      {
+        "id": 18233,
+        "recipientId": 53790,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/323/200/200",
+        "relationship": "친구",
+        "content": "송혜교님의 메세지 내용 35",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-07-03T01:10:13Z"
+      },
+      {
+        "id": 61256,
+        "recipientId": 53790,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/121/200/200",
+        "relationship": "지인",
+        "content": "정우성님의 메세지 내용 80",
+        "font": "Roboto",
+        "createdAt": "2023-10-21T06:37:14Z"
+      },
+      {
+        "id": 44921,
+        "recipientId": 53790,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/398/200/200",
+        "relationship": "친구",
+        "content": "김하은님의 메세지 내용 45",
+        "font": "Noto Sans",
+        "createdAt": "2023-06-24T09:03:26Z"
+      }
+    ],
+    "reactionCount": 64,
+    "topReactions": [
+      {
+        "id": 3352,
+        "emoji": "👍",
+        "count": 10
+      },
+      {
+        "id": 39601,
+        "emoji": "😀",
+        "count": 10
+      },
+      {
+        "id": 11421,
+        "emoji": "🎉",
+        "count": 5
+      },
+      {
+        "id": 35027,
+        "emoji": "🎉",
+        "count": 10
+      }
+    ]
+  },
+  {
+    "id": 79165,
+    "name": "이영준",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/79165/600/400",
+    "createdAt": "2023-06-19T21:21:37Z",
+    "messageCount": 1,
+    "recentMessages": [
+      {
+        "id": 35200,
+        "recipientId": 79165,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/66/200/200",
+        "relationship": "지인",
+        "content": "송혜교님의 메세지 내용 94",
+        "font": "Noto Sans",
+        "createdAt": "2023-01-31T01:24:39Z"
+      }
+    ],
+    "reactionCount": 43,
+    "topReactions": [
+      {
+        "id": 8574,
+        "emoji": "🎉",
+        "count": 7
+      },
+      {
+        "id": 64170,
+        "emoji": "❤️",
+        "count": 8
+      }
+    ]
+  },
+  {
+    "id": 28312,
+    "name": "현빈",
+    "backgroundColor": "green",
+    "backgroundImageURL": null,
+    "createdAt": "2024-02-02T23:39:16Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 48020,
+        "recipientId": 28312,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/405/200/200",
+        "relationship": "지인",
+        "content": "한지민님의 메세지 내용 64",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-12-24T00:02:37Z"
+      },
+      {
+        "id": 20798,
+        "recipientId": 28312,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/435/200/200",
+        "relationship": "가족",
+        "content": "한지민님의 메세지 내용 83",
+        "font": "Noto Sans",
+        "createdAt": "2023-04-23T15:30:26Z"
+      },
+      {
+        "id": 87481,
+        "recipientId": 28312,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/284/200/200",
+        "relationship": "지인",
+        "content": "한지민님의 메세지 내용 11",
+        "font": "Pretendard",
+        "createdAt": "2023-05-11T12:13:58Z"
+      }
+    ],
+    "reactionCount": 31,
+    "topReactions": [
+      {
+        "id": 9532,
+        "emoji": "🎉",
+        "count": 15
+      },
+      {
+        "id": 71554,
+        "emoji": "🎉",
+        "count": 3
+      },
+      {
+        "id": 39488,
+        "emoji": "👍",
+        "count": 14
+      }
+    ]
+  },
+  {
+    "id": 63671,
+    "name": "송혜교",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-11-27T08:35:03Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 38644,
+        "recipientId": 63671,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/254/200/200",
+        "relationship": "지인",
+        "content": "박서준님의 메세지 내용 13",
+        "font": "Roboto",
+        "createdAt": "2023-03-06T23:53:26Z"
+      },
+      {
+        "id": 83644,
+        "recipientId": 63671,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/4/200/200",
+        "relationship": "지인",
+        "content": "한지민님의 메세지 내용 65",
+        "font": "Noto Sans",
+        "createdAt": "2023-05-26T11:25:25Z"
+      },
+      {
+        "id": 17855,
+        "recipientId": 63671,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/100/200/200",
+        "relationship": "친구",
+        "content": "현빈님의 메세지 내용 56",
+        "font": "Noto Sans",
+        "createdAt": "2023-06-05T01:49:30Z"
+      }
+    ],
+    "reactionCount": 33,
+    "topReactions": [
+      {
+        "id": 52748,
+        "emoji": "👍",
+        "count": 10
+      },
+      {
+        "id": 16337,
+        "emoji": "😁",
+        "count": 12
+      },
+      {
+        "id": 61443,
+        "emoji": "🥹",
+        "count": 20
+      },
+      {
+        "id": 68842,
+        "emoji": "😁",
+        "count": 16
+      },
+      {
+        "id": 32585,
+        "emoji": "🎉",
+        "count": 10
+      },
+      {
+        "id": 71746,
+        "emoji": "😁",
+        "count": 9
+      }
+    ]
+  },
+  {
+    "id": 68523,
+    "name": "박서준",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/68523/600/400",
+    "createdAt": "2023-01-29T05:15:30Z",
+    "messageCount": 6,
+    "recentMessages": [
+      {
+        "id": 24735,
+        "recipientId": 68523,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/60/200/200",
+        "relationship": "가족",
+        "content": "김하은님의 메세지 내용 99",
+        "font": "Pretendard",
+        "createdAt": "2023-10-16T13:33:28Z"
+      },
+      {
+        "id": 98757,
+        "recipientId": 68523,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/486/200/200",
+        "relationship": "지인",
+        "content": "박서준님의 메세지 내용 21",
+        "font": "Nanum Gothic",
+        "createdAt": "2024-01-13T00:27:10Z"
+      },
+      {
+        "id": 34120,
+        "recipientId": 68523,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/294/200/200",
+        "relationship": "친구",
+        "content": "송혜교님의 메세지 내용 73",
+        "font": "Pretendard",
+        "createdAt": "2023-11-11T07:45:22Z"
+      }
+    ],
+    "reactionCount": 74,
+    "topReactions": [
+      {
+        "id": 47111,
+        "emoji": "👍",
+        "count": 12
+      },
+      {
+        "id": 67878,
+        "emoji": "😀",
+        "count": 16
+      },
+      {
+        "id": 49575,
+        "emoji": "😀",
+        "count": 10
+      },
+      {
+        "id": 72740,
+        "emoji": "🎉",
+        "count": 15
+      },
+      {
+        "id": 66239,
+        "emoji": "❤️",
+        "count": 16
+      },
+      {
+        "id": 78326,
+        "emoji": "🥹",
+        "count": 14
+      }
+    ]
+  },
+  {
+    "id": 73648,
+    "name": "한지민",
+    "backgroundColor": "blue",
+    "backgroundImageURL": null,
+    "createdAt": "2023-05-23T17:26:38Z",
+    "messageCount": 6,
+    "recentMessages": [
+      {
+        "id": 47579,
+        "recipientId": 73648,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/331/200/200",
+        "relationship": "지인",
+        "content": "현빈님의 메세지 내용 11",
+        "font": "Roboto",
+        "createdAt": "2023-12-19T14:09:40Z"
+      },
+      {
+        "id": 96788,
+        "recipientId": 73648,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/249/200/200",
+        "relationship": "가족",
+        "content": "이병헌님의 메세지 내용 54",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-09-16T01:58:06Z"
+      },
+      {
+        "id": 20726,
+        "recipientId": 73648,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/431/200/200",
+        "relationship": "친구",
+        "content": "이병헌님의 메세지 내용 78",
+        "font": "Pretendard",
+        "createdAt": "2023-07-25T07:59:44Z"
+      }
+    ],
+    "reactionCount": 45,
+    "topReactions": [
+      {
+        "id": 86527,
+        "emoji": "😁",
+        "count": 15
+      },
+      {
+        "id": 59551,
+        "emoji": "🥹",
+        "count": 16
+      },
+      {
+        "id": 3729,
+        "emoji": "😀",
+        "count": 2
+      },
+      {
+        "id": 29902,
+        "emoji": "🎉",
+        "count": 12
+      },
+      {
+        "id": 39150,
+        "emoji": "❤️",
+        "count": 19
+      }
+    ]
+  },
+  {
+    "id": 3519,
+    "name": "이영준",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/3519/600/400",
+    "createdAt": "2023-03-07T10:55:33Z",
+    "messageCount": 1,
+    "recentMessages": [
+      {
+        "id": 49350,
+        "recipientId": 3519,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/37/200/200",
+        "relationship": "동료",
+        "content": "김하은님의 메세지 내용 49",
+        "font": "Roboto",
+        "createdAt": "2023-12-23T10:53:50Z"
+      }
+    ],
+    "reactionCount": 59,
+    "topReactions": [
+      {
+        "id": 93221,
+        "emoji": "👍",
+        "count": 1
+      },
+      {
+        "id": 95714,
+        "emoji": "🎉",
+        "count": 8
+      },
+      {
+        "id": 8397,
+        "emoji": "🎉",
+        "count": 16
+      },
+      {
+        "id": 70176,
+        "emoji": "🎉",
+        "count": 9
+      },
+      {
+        "id": 67165,
+        "emoji": "🎉",
+        "count": 10
+      },
+      {
+        "id": 41000,
+        "emoji": "👍",
+        "count": 7
+      }
+    ]
+  },
+  {
+    "id": 29324,
+    "name": "전지현",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-11-15T12:34:37Z",
+    "messageCount": 1,
+    "recentMessages": [
+      {
+        "id": 66891,
+        "recipientId": 29324,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/150/200/200",
+        "relationship": "지인",
+        "content": "이영준님의 메세지 내용 28",
+        "font": "Roboto",
+        "createdAt": "2024-01-16T01:09:36Z"
+      }
+    ],
+    "reactionCount": 91,
+    "topReactions": [
+      {
+        "id": 72115,
+        "emoji": "👍",
+        "count": 5
+      },
+      {
+        "id": 91626,
+        "emoji": "❤️",
+        "count": 18
+      },
+      {
+        "id": 19336,
+        "emoji": "😀",
+        "count": 4
+      }
+    ]
+  },
+  {
+    "id": 34799,
+    "name": "최민수",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/34799/600/400",
+    "createdAt": "2023-05-26T14:19:32Z",
+    "messageCount": 5,
+    "recentMessages": [
+      {
+        "id": 64083,
+        "recipientId": 34799,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/269/200/200",
+        "relationship": "동료",
+        "content": "정우성님의 메세지 내용 15",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-09-02T06:05:45Z"
+      },
+      {
+        "id": 29589,
+        "recipientId": 34799,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/471/200/200",
+        "relationship": "지인",
+        "content": "박서준님의 메세지 내용 7",
+        "font": "Noto Sans",
+        "createdAt": "2023-06-15T19:01:12Z"
+      },
+      {
+        "id": 30989,
+        "recipientId": 34799,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/129/200/200",
+        "relationship": "지인",
+        "content": "박서준님의 메세지 내용 45",
+        "font": "Roboto",
+        "createdAt": "2023-03-23T13:04:58Z"
+      }
+    ],
+    "reactionCount": 8,
+    "topReactions": [
+      {
+        "id": 3482,
+        "emoji": "👍",
+        "count": 18
+      },
+      {
+        "id": 66591,
+        "emoji": "🥹",
+        "count": 7
+      },
+      {
+        "id": 38585,
+        "emoji": "🥹",
+        "count": 19
+      }
+    ]
+  },
+  {
+    "id": 35446,
+    "name": "현빈",
+    "backgroundColor": "blue",
+    "backgroundImageURL": null,
+    "createdAt": "2023-12-14T18:07:09Z",
+    "messageCount": 5,
+    "recentMessages": [
+      {
+        "id": 58428,
+        "recipientId": 35446,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/426/200/200",
+        "relationship": "지인",
+        "content": "최민수님의 메세지 내용 29",
+        "font": "Noto Sans",
+        "createdAt": "2023-09-15T23:26:36Z"
+      },
+      {
+        "id": 58296,
+        "recipientId": 35446,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/211/200/200",
+        "relationship": "동료",
+        "content": "최민수님의 메세지 내용 44",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-01-01T12:11:21Z"
+      },
+      {
+        "id": 2388,
+        "recipientId": 35446,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/489/200/200",
+        "relationship": "동료",
+        "content": "박서준님의 메세지 내용 92",
+        "font": "Noto Sans",
+        "createdAt": "2023-01-24T10:23:16Z"
+      }
+    ],
+    "reactionCount": 68,
+    "topReactions": [
+      {
+        "id": 59908,
+        "emoji": "❤️",
+        "count": 9
+      },
+      {
+        "id": 88137,
+        "emoji": "❤️",
+        "count": 18
+      },
+      {
+        "id": 73395,
+        "emoji": "😀",
+        "count": 1
+      },
+      {
+        "id": 1194,
+        "emoji": "👍",
+        "count": 7
+      }
+    ]
+  },
+  {
+    "id": 43465,
+    "name": "이영준",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/43465/600/400",
+    "createdAt": "2023-06-17T10:24:36Z",
+    "messageCount": 3,
+    "recentMessages": [
+      {
+        "id": 49416,
+        "recipientId": 43465,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/159/200/200",
+        "relationship": "가족",
+        "content": "이영준님의 메세지 내용 31",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-09-13T13:59:21Z"
+      },
+      {
+        "id": 47626,
+        "recipientId": 43465,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/428/200/200",
+        "relationship": "가족",
+        "content": "현빈님의 메세지 내용 40",
+        "font": "Pretendard",
+        "createdAt": "2023-06-13T04:40:39Z"
+      },
+      {
+        "id": 38141,
+        "recipientId": 43465,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/165/200/200",
+        "relationship": "친구",
+        "content": "한지민님의 메세지 내용 19",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-03-01T14:53:42Z"
+      }
+    ],
+    "reactionCount": 32,
+    "topReactions": [
+      {
+        "id": 91871,
+        "emoji": "🎉",
+        "count": 13
+      },
+      {
+        "id": 78009,
+        "emoji": "🎉",
+        "count": 6
+      },
+      {
+        "id": 19885,
+        "emoji": "😁",
+        "count": 16
+      },
+      {
+        "id": 93729,
+        "emoji": "❤️",
+        "count": 19
+      },
+      {
+        "id": 57682,
+        "emoji": "🥹",
+        "count": 19
+      },
+      {
+        "id": 6511,
+        "emoji": "🎉",
+        "count": 15
+      }
+    ]
+  },
+  {
+    "id": 35138,
+    "name": "정우성",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/35138/600/400",
+    "createdAt": "2023-10-26T18:11:01Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 28846,
+        "recipientId": 35138,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/383/200/200",
+        "relationship": "지인",
+        "content": "현빈님의 메세지 내용 85",
+        "font": "Pretendard",
+        "createdAt": "2023-10-31T04:33:01Z"
+      },
+      {
+        "id": 67016,
+        "recipientId": 35138,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/473/200/200",
+        "relationship": "지인",
+        "content": "정우성님의 메세지 내용 30",
+        "font": "Noto Sans",
+        "createdAt": "2023-08-22T17:48:28Z"
+      },
+      {
+        "id": 26345,
+        "recipientId": 35138,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/424/200/200",
+        "relationship": "친구",
+        "content": "최민수님의 메세지 내용 77",
+        "font": "Roboto",
+        "createdAt": "2023-08-06T00:17:22Z"
+      }
+    ],
+    "reactionCount": 53,
+    "topReactions": [
+      {
+        "id": 14727,
+        "emoji": "🥹",
+        "count": 20
+      },
+      {
+        "id": 66436,
+        "emoji": "🎉",
+        "count": 5
+      },
+      {
+        "id": 36308,
+        "emoji": "👍",
+        "count": 14
+      },
+      {
+        "id": 21367,
+        "emoji": "😁",
+        "count": 18
+      },
+      {
+        "id": 12087,
+        "emoji": "😁",
+        "count": 9
+      }
+    ]
+  },
+  {
+    "id": 57025,
+    "name": "최민수",
+    "backgroundColor": "green",
+    "backgroundImageURL": null,
+    "createdAt": "2023-09-24T09:40:21Z",
+    "messageCount": 2,
+    "recentMessages": [
+      {
+        "id": 86332,
+        "recipientId": 57025,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/66/200/200",
+        "relationship": "친구",
+        "content": "현빈님의 메세지 내용 3",
+        "font": "Noto Sans",
+        "createdAt": "2023-08-27T00:28:01Z"
+      },
+      {
+        "id": 62727,
+        "recipientId": 57025,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/322/200/200",
+        "relationship": "가족",
+        "content": "박서준님의 메세지 내용 24",
+        "font": "Roboto",
+        "createdAt": "2023-02-01T13:03:37Z"
+      }
+    ],
+    "reactionCount": 97,
+    "topReactions": [
+      {
+        "id": 57205,
+        "emoji": "👍",
+        "count": 19
+      }
+    ]
+  },
+  {
+    "id": 73391,
+    "name": "전지현",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/73391/600/400",
+    "createdAt": "2024-01-13T03:42:57Z",
+    "messageCount": 7,
+    "recentMessages": [
+      {
+        "id": 55060,
+        "recipientId": 73391,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/255/200/200",
+        "relationship": "지인",
+        "content": "박서준님의 메세지 내용 54",
+        "font": "Roboto",
+        "createdAt": "2023-11-01T01:54:10Z"
+      },
+      {
+        "id": 73020,
+        "recipientId": 73391,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/124/200/200",
+        "relationship": "동료",
+        "content": "김하은님의 메세지 내용 61",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-06-28T02:59:56Z"
+      },
+      {
+        "id": 65998,
+        "recipientId": 73391,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/117/200/200",
+        "relationship": "가족",
+        "content": "이병헌님의 메세지 내용 7",
+        "font": "Noto Sans",
+        "createdAt": "2023-06-29T21:54:39Z"
+      }
+    ],
+    "reactionCount": 64,
+    "topReactions": [
+      {
+        "id": 87665,
+        "emoji": "🎉",
+        "count": 12
+      }
+    ]
+  },
+  {
+    "id": 14280,
+    "name": "송혜교",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2023-08-01T17:10:49Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 56101,
+        "recipientId": 14280,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/371/200/200",
+        "relationship": "친구",
+        "content": "전지현님의 메세지 내용 71",
+        "font": "Pretendard",
+        "createdAt": "2023-06-06T07:40:33Z"
+      },
+      {
+        "id": 95535,
+        "recipientId": 14280,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/31/200/200",
+        "relationship": "지인",
+        "content": "송혜교님의 메세지 내용 13",
+        "font": "Noto Sans",
+        "createdAt": "2023-01-24T13:48:36Z"
+      },
+      {
+        "id": 61373,
+        "recipientId": 14280,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/378/200/200",
+        "relationship": "동료",
+        "content": "전지현님의 메세지 내용 94",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-10-05T12:57:26Z"
+      }
+    ],
+    "reactionCount": 18,
+    "topReactions": [
+      {
+        "id": 55291,
+        "emoji": "😁",
+        "count": 15
+      },
+      {
+        "id": 90016,
+        "emoji": "❤️",
+        "count": 15
+      },
+      {
+        "id": 84184,
+        "emoji": "😁",
+        "count": 9
+      },
+      {
+        "id": 43715,
+        "emoji": "🥹",
+        "count": 3
+      },
+      {
+        "id": 62315,
+        "emoji": "🎉",
+        "count": 6
+      },
+      {
+        "id": 34308,
+        "emoji": "🎉",
+        "count": 12
+      }
+    ]
+  },
+  {
+    "id": 62767,
+    "name": "최민수",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-02-20T13:06:25Z",
+    "messageCount": 6,
+    "recentMessages": [
+      {
+        "id": 88527,
+        "recipientId": 62767,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/344/200/200",
+        "relationship": "친구",
+        "content": "정우성님의 메세지 내용 55",
+        "font": "Noto Sans",
+        "createdAt": "2023-08-22T10:55:21Z"
+      },
+      {
+        "id": 13081,
+        "recipientId": 62767,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/354/200/200",
+        "relationship": "동료",
+        "content": "박서준님의 메세지 내용 29",
+        "font": "Roboto",
+        "createdAt": "2024-01-03T06:33:31Z"
+      },
+      {
+        "id": 60642,
+        "recipientId": 62767,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/378/200/200",
+        "relationship": "친구",
+        "content": "현빈님의 메세지 내용 48",
+        "font": "Noto Sans",
+        "createdAt": "2023-05-16T05:34:20Z"
+      }
+    ],
+    "reactionCount": 64,
+    "topReactions": [
+      {
+        "id": 27890,
+        "emoji": "🥹",
+        "count": 12
+      },
+      {
+        "id": 56175,
+        "emoji": "👍",
+        "count": 17
+      },
+      {
+        "id": 91877,
+        "emoji": "🥹",
+        "count": 6
+      },
+      {
+        "id": 69359,
+        "emoji": "😀",
+        "count": 7
+      },
+      {
+        "id": 52444,
+        "emoji": "❤️",
+        "count": 19
+      },
+      {
+        "id": 40782,
+        "emoji": "😁",
+        "count": 13
+      }
+    ]
+  },
+  {
+    "id": 7728,
+    "name": "이영준",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/7728/600/400",
+    "createdAt": "2023-09-25T02:59:47Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 37394,
+        "recipientId": 7728,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/309/200/200",
+        "relationship": "친구",
+        "content": "현빈님의 메세지 내용 74",
+        "font": "Noto Sans",
+        "createdAt": "2023-03-21T04:47:53Z"
+      },
+      {
+        "id": 88123,
+        "recipientId": 7728,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/370/200/200",
+        "relationship": "지인",
+        "content": "김하은님의 메세지 내용 25",
+        "font": "Pretendard",
+        "createdAt": "2023-08-14T12:27:46Z"
+      },
+      {
+        "id": 43663,
+        "recipientId": 7728,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/444/200/200",
+        "relationship": "친구",
+        "content": "한지민님의 메세지 내용 84",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-12-29T08:07:41Z"
+      }
+    ],
+    "reactionCount": 36,
+    "topReactions": [
+      {
+        "id": 76073,
+        "emoji": "🥹",
+        "count": 8
+      },
+      {
+        "id": 96332,
+        "emoji": "🎉",
+        "count": 17
+      },
+      {
+        "id": 10485,
+        "emoji": "🥹",
+        "count": 5
+      },
+      {
+        "id": 59065,
+        "emoji": "👍",
+        "count": 7
+      }
+    ]
+  },
+  {
+    "id": 26744,
+    "name": "이병헌",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-03-23T03:14:00Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 71764,
+        "recipientId": 26744,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/311/200/200",
+        "relationship": "친구",
+        "content": "전지현님의 메세지 내용 72",
+        "font": "Roboto",
+        "createdAt": "2023-05-07T16:58:02Z"
+      },
+      {
+        "id": 64322,
+        "recipientId": 26744,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/6/200/200",
+        "relationship": "친구",
+        "content": "현빈님의 메세지 내용 11",
+        "font": "Roboto",
+        "createdAt": "2023-12-03T19:24:09Z"
+      },
+      {
+        "id": 94348,
+        "recipientId": 26744,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/84/200/200",
+        "relationship": "친구",
+        "content": "최민수님의 메세지 내용 100",
+        "font": "Pretendard",
+        "createdAt": "2023-11-23T06:33:34Z"
+      }
+    ],
+    "reactionCount": 96,
+    "topReactions": [
+      {
+        "id": 43701,
+        "emoji": "😁",
+        "count": 11
+      },
+      {
+        "id": 56499,
+        "emoji": "🎉",
+        "count": 3
+      },
+      {
+        "id": 84055,
+        "emoji": "😀",
+        "count": 11
+      },
+      {
+        "id": 17678,
+        "emoji": "🥹",
+        "count": 15
+      },
+      {
+        "id": 79009,
+        "emoji": "❤️",
+        "count": 17
+      },
+      {
+        "id": 77257,
+        "emoji": "😀",
+        "count": 8
+      }
+    ]
+  },
+  {
+    "id": 93103,
+    "name": "현빈",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/93103/600/400",
+    "createdAt": "2023-01-01T05:08:24Z",
+    "messageCount": 10,
+    "recentMessages": [
+      {
+        "id": 5540,
+        "recipientId": 93103,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/74/200/200",
+        "relationship": "동료",
+        "content": "최민수님의 메세지 내용 49",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-03-28T10:31:32Z"
+      },
+      {
+        "id": 50339,
+        "recipientId": 93103,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/74/200/200",
+        "relationship": "지인",
+        "content": "박서준님의 메세지 내용 12",
+        "font": "Noto Sans",
+        "createdAt": "2023-10-03T18:22:10Z"
+      },
+      {
+        "id": 75277,
+        "recipientId": 93103,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/165/200/200",
+        "relationship": "친구",
+        "content": "김하은님의 메세지 내용 17",
+        "font": "Roboto",
+        "createdAt": "2023-07-28T04:12:32Z"
+      }
+    ],
+    "reactionCount": 57,
+    "topReactions": [
+      {
+        "id": 14687,
+        "emoji": "😀",
+        "count": 19
+      },
+      {
+        "id": 39344,
+        "emoji": "👍",
+        "count": 7
+      },
+      {
+        "id": 34161,
+        "emoji": "🎉",
+        "count": 13
+      },
+      {
+        "id": 35565,
+        "emoji": "🎉",
+        "count": 16
+      }
+    ]
+  },
+  {
+    "id": 90477,
+    "name": "현빈",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/90477/600/400",
+    "createdAt": "2023-03-02T13:15:54Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 35228,
+        "recipientId": 90477,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/94/200/200",
+        "relationship": "친구",
+        "content": "이병헌님의 메세지 내용 63",
+        "font": "Roboto",
+        "createdAt": "2023-05-25T06:02:55Z"
+      },
+      {
+        "id": 50401,
+        "recipientId": 90477,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/89/200/200",
+        "relationship": "동료",
+        "content": "현빈님의 메세지 내용 84",
+        "font": "Pretendard",
+        "createdAt": "2024-01-09T23:38:08Z"
+      },
+      {
+        "id": 95955,
+        "recipientId": 90477,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/472/200/200",
+        "relationship": "친구",
+        "content": "최민수님의 메세지 내용 21",
+        "font": "Pretendard",
+        "createdAt": "2023-08-01T20:07:21Z"
+      }
+    ],
+    "reactionCount": 96,
+    "topReactions": [
+      {
+        "id": 23630,
+        "emoji": "🥹",
+        "count": 19
+      },
+      {
+        "id": 94766,
+        "emoji": "😁",
+        "count": 3
+      },
+      {
+        "id": 59725,
+        "emoji": "😀",
+        "count": 19
+      }
+    ]
+  },
+  {
+    "id": 82677,
+    "name": "김하은",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/82677/600/400",
+    "createdAt": "2023-02-13T13:40:06Z",
+    "messageCount": 10,
+    "recentMessages": [
+      {
+        "id": 90214,
+        "recipientId": 82677,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/195/200/200",
+        "relationship": "친구",
+        "content": "정우성님의 메세지 내용 99",
+        "font": "Pretendard",
+        "createdAt": "2023-07-17T22:33:03Z"
+      },
+      {
+        "id": 9562,
+        "recipientId": 82677,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/92/200/200",
+        "relationship": "지인",
+        "content": "한지민님의 메세지 내용 67",
+        "font": "Roboto",
+        "createdAt": "2023-07-31T01:08:53Z"
+      },
+      {
+        "id": 84870,
+        "recipientId": 82677,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/420/200/200",
+        "relationship": "동료",
+        "content": "현빈님의 메세지 내용 46",
+        "font": "Roboto",
+        "createdAt": "2023-12-17T05:44:51Z"
+      }
+    ],
+    "reactionCount": 76,
+    "topReactions": [
+      {
+        "id": 15262,
+        "emoji": "😀",
+        "count": 8
+      },
+      {
+        "id": 76672,
+        "emoji": "👍",
+        "count": 12
+      },
+      {
+        "id": 85829,
+        "emoji": "😀",
+        "count": 14
+      },
+      {
+        "id": 86733,
+        "emoji": "❤️",
+        "count": 13
+      }
+    ]
+  },
+  {
+    "id": 92597,
+    "name": "현빈",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/92597/600/400",
+    "createdAt": "2023-06-08T00:17:35Z",
+    "messageCount": 3,
+    "recentMessages": [
+      {
+        "id": 32441,
+        "recipientId": 92597,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/130/200/200",
+        "relationship": "동료",
+        "content": "송혜교님의 메세지 내용 20",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-03-13T15:52:33Z"
+      },
+      {
+        "id": 30686,
+        "recipientId": 92597,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/301/200/200",
+        "relationship": "가족",
+        "content": "박서준님의 메세지 내용 76",
+        "font": "Roboto",
+        "createdAt": "2023-05-31T09:51:47Z"
+      },
+      {
+        "id": 65036,
+        "recipientId": 92597,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/20/200/200",
+        "relationship": "가족",
+        "content": "전지현님의 메세지 내용 72",
+        "font": "Pretendard",
+        "createdAt": "2023-12-21T10:58:20Z"
+      }
+    ],
+    "reactionCount": 54,
+    "topReactions": [
+      {
+        "id": 74781,
+        "emoji": "🎉",
+        "count": 3
+      },
+      {
+        "id": 8118,
+        "emoji": "😁",
+        "count": 19
+      },
+      {
+        "id": 42107,
+        "emoji": "🥹",
+        "count": 7
+      }
+    ]
+  },
+  {
+    "id": 86205,
+    "name": "최민수",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-11-27T17:51:50Z",
+    "messageCount": 7,
+    "recentMessages": [
+      {
+        "id": 96831,
+        "recipientId": 86205,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/348/200/200",
+        "relationship": "친구",
+        "content": "전지현님의 메세지 내용 44",
+        "font": "Roboto",
+        "createdAt": "2023-08-13T20:07:55Z"
+      },
+      {
+        "id": 20859,
+        "recipientId": 86205,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/266/200/200",
+        "relationship": "친구",
+        "content": "정우성님의 메세지 내용 81",
+        "font": "Noto Sans",
+        "createdAt": "2023-04-17T18:16:14Z"
+      },
+      {
+        "id": 55279,
+        "recipientId": 86205,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/483/200/200",
+        "relationship": "가족",
+        "content": "현빈님의 메세지 내용 69",
+        "font": "Noto Sans",
+        "createdAt": "2024-01-27T19:13:38Z"
+      }
+    ],
+    "reactionCount": 89,
+    "topReactions": [
+      {
+        "id": 12830,
+        "emoji": "🥹",
+        "count": 5
+      },
+      {
+        "id": 70733,
+        "emoji": "😁",
+        "count": 8
+      }
+    ]
+  },
+  {
+    "id": 83780,
+    "name": "송혜교",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-02-24T11:43:37Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 10008,
+        "recipientId": 83780,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/464/200/200",
+        "relationship": "동료",
+        "content": "한지민님의 메세지 내용 84",
+        "font": "Roboto",
+        "createdAt": "2024-01-11T21:23:27Z"
+      },
+      {
+        "id": 6414,
+        "recipientId": 83780,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/104/200/200",
+        "relationship": "지인",
+        "content": "전지현님의 메세지 내용 56",
+        "font": "Roboto",
+        "createdAt": "2023-01-11T02:47:15Z"
+      },
+      {
+        "id": 5190,
+        "recipientId": 83780,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/119/200/200",
+        "relationship": "친구",
+        "content": "최민수님의 메세지 내용 2",
+        "font": "Pretendard",
+        "createdAt": "2023-04-24T17:49:24Z"
+      }
+    ],
+    "reactionCount": 81,
+    "topReactions": [
+      {
+        "id": 1589,
+        "emoji": "🥹",
+        "count": 15
+      },
+      {
+        "id": 78183,
+        "emoji": "🎉",
+        "count": 19
+      },
+      {
+        "id": 22247,
+        "emoji": "🎉",
+        "count": 1
+      },
+      {
+        "id": 19112,
+        "emoji": "🥹",
+        "count": 17
+      }
+    ]
+  },
+  {
+    "id": 38229,
+    "name": "송혜교",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/38229/600/400",
+    "createdAt": "2023-01-30T14:18:54Z",
+    "messageCount": 7,
+    "recentMessages": [
+      {
+        "id": 51942,
+        "recipientId": 38229,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/134/200/200",
+        "relationship": "지인",
+        "content": "현빈님의 메세지 내용 54",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-03-20T04:36:24Z"
+      },
+      {
+        "id": 86324,
+        "recipientId": 38229,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/233/200/200",
+        "relationship": "친구",
+        "content": "정우성님의 메세지 내용 86",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-10-10T17:45:30Z"
+      },
+      {
+        "id": 90356,
+        "recipientId": 38229,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/229/200/200",
+        "relationship": "친구",
+        "content": "최민수님의 메세지 내용 59",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-03-24T14:49:12Z"
+      }
+    ],
+    "reactionCount": 59,
+    "topReactions": [
+      {
+        "id": 34874,
+        "emoji": "❤️",
+        "count": 15
+      },
+      {
+        "id": 26479,
+        "emoji": "😁",
+        "count": 1
+      },
+      {
+        "id": 35105,
+        "emoji": "🎉",
+        "count": 18
+      },
+      {
+        "id": 6384,
+        "emoji": "😀",
+        "count": 13
+      },
+      {
+        "id": 70298,
+        "emoji": "🥹",
+        "count": 9
+      },
+      {
+        "id": 48862,
+        "emoji": "😁",
+        "count": 11
+      }
+    ]
+  },
+  {
+    "id": 31714,
+    "name": "이병헌",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/31714/600/400",
+    "createdAt": "2023-01-13T08:26:56Z",
+    "messageCount": 1,
+    "recentMessages": [
+      {
+        "id": 13368,
+        "recipientId": 31714,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/274/200/200",
+        "relationship": "동료",
+        "content": "송혜교님의 메세지 내용 54",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-08-29T23:09:43Z"
+      }
+    ],
+    "reactionCount": 15,
+    "topReactions": [
+      {
+        "id": 84856,
+        "emoji": "😀",
+        "count": 2
+      },
+      {
+        "id": 37418,
+        "emoji": "😁",
+        "count": 16
+      },
+      {
+        "id": 68962,
+        "emoji": "🥹",
+        "count": 16
+      },
+      {
+        "id": 63309,
+        "emoji": "🥹",
+        "count": 8
+      }
+    ]
+  },
+  {
+    "id": 24976,
+    "name": "전지현",
+    "backgroundColor": "blue",
+    "backgroundImageURL": null,
+    "createdAt": "2023-12-12T12:27:23Z",
+    "messageCount": 6,
+    "recentMessages": [
+      {
+        "id": 21316,
+        "recipientId": 24976,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/106/200/200",
+        "relationship": "지인",
+        "content": "이영준님의 메세지 내용 56",
+        "font": "Roboto",
+        "createdAt": "2023-01-09T20:33:19Z"
+      },
+      {
+        "id": 58002,
+        "recipientId": 24976,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/183/200/200",
+        "relationship": "가족",
+        "content": "송혜교님의 메세지 내용 81",
+        "font": "Roboto",
+        "createdAt": "2023-01-08T15:28:27Z"
+      },
+      {
+        "id": 88820,
+        "recipientId": 24976,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/355/200/200",
+        "relationship": "동료",
+        "content": "이병헌님의 메세지 내용 72",
+        "font": "Pretendard",
+        "createdAt": "2023-12-02T16:28:28Z"
+      }
+    ],
+    "reactionCount": 14,
+    "topReactions": [
+      {
+        "id": 23520,
+        "emoji": "😁",
+        "count": 1
+      },
+      {
+        "id": 1327,
+        "emoji": "🎉",
+        "count": 6
+      },
+      {
+        "id": 99333,
+        "emoji": "😀",
+        "count": 7
+      },
+      {
+        "id": 24221,
+        "emoji": "😁",
+        "count": 8
+      },
+      {
+        "id": 34796,
+        "emoji": "👍",
+        "count": 13
+      },
+      {
+        "id": 24544,
+        "emoji": "🎉",
+        "count": 5
+      }
+    ]
+  },
+  {
+    "id": 13246,
+    "name": "현빈",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/13246/600/400",
+    "createdAt": "2024-01-28T13:20:43Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 5106,
+        "recipientId": 13246,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/198/200/200",
+        "relationship": "동료",
+        "content": "현빈님의 메세지 내용 81",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-08-15T19:24:32Z"
+      },
+      {
+        "id": 14675,
+        "recipientId": 13246,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/378/200/200",
+        "relationship": "친구",
+        "content": "한지민님의 메세지 내용 100",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-12-09T18:47:45Z"
+      },
+      {
+        "id": 88634,
+        "recipientId": 13246,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/286/200/200",
+        "relationship": "가족",
+        "content": "김하은님의 메세지 내용 3",
+        "font": "Pretendard",
+        "createdAt": "2023-06-16T01:43:57Z"
+      }
+    ],
+    "reactionCount": 26,
+    "topReactions": [
+      {
+        "id": 67233,
+        "emoji": "🥹",
+        "count": 18
+      },
+      {
+        "id": 15477,
+        "emoji": "😁",
+        "count": 6
+      },
+      {
+        "id": 52552,
+        "emoji": "😁",
+        "count": 2
+      },
+      {
+        "id": 4534,
+        "emoji": "❤️",
+        "count": 5
+      },
+      {
+        "id": 81700,
+        "emoji": "🎉",
+        "count": 5
+      }
+    ]
+  },
+  {
+    "id": 80427,
+    "name": "김하은",
+    "backgroundColor": "blue",
+    "backgroundImageURL": null,
+    "createdAt": "2023-07-18T23:35:46Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 27419,
+        "recipientId": 80427,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/496/200/200",
+        "relationship": "지인",
+        "content": "김하은님의 메세지 내용 32",
+        "font": "Pretendard",
+        "createdAt": "2023-04-12T22:20:48Z"
+      },
+      {
+        "id": 6424,
+        "recipientId": 80427,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/148/200/200",
+        "relationship": "동료",
+        "content": "이영준님의 메세지 내용 81",
+        "font": "Noto Sans",
+        "createdAt": "2024-01-17T02:57:29Z"
+      },
+      {
+        "id": 80098,
+        "recipientId": 80427,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/163/200/200",
+        "relationship": "동료",
+        "content": "한지민님의 메세지 내용 100",
+        "font": "Noto Sans",
+        "createdAt": "2023-07-13T01:55:00Z"
+      }
+    ],
+    "reactionCount": 60,
+    "topReactions": [
+      {
+        "id": 67321,
+        "emoji": "😀",
+        "count": 10
+      },
+      {
+        "id": 37472,
+        "emoji": "🥹",
+        "count": 12
+      },
+      {
+        "id": 38481,
+        "emoji": "😁",
+        "count": 5
+      },
+      {
+        "id": 10179,
+        "emoji": "😁",
+        "count": 14
+      }
+    ]
+  },
+  {
+    "id": 9191,
+    "name": "박서준",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/9191/600/400",
+    "createdAt": "2023-12-26T20:03:21Z",
+    "messageCount": 5,
+    "recentMessages": [
+      {
+        "id": 35658,
+        "recipientId": 9191,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/62/200/200",
+        "relationship": "동료",
+        "content": "이병헌님의 메세지 내용 27",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-04-09T12:56:46Z"
+      },
+      {
+        "id": 20743,
+        "recipientId": 9191,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/59/200/200",
+        "relationship": "동료",
+        "content": "송혜교님의 메세지 내용 23",
+        "font": "Noto Sans",
+        "createdAt": "2023-05-09T21:29:01Z"
+      },
+      {
+        "id": 20041,
+        "recipientId": 9191,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/114/200/200",
+        "relationship": "가족",
+        "content": "이병헌님의 메세지 내용 72",
+        "font": "Pretendard",
+        "createdAt": "2023-11-11T12:43:30Z"
+      }
+    ],
+    "reactionCount": 90,
+    "topReactions": [
+      {
+        "id": 46794,
+        "emoji": "🎉",
+        "count": 2
+      },
+      {
+        "id": 78569,
+        "emoji": "😁",
+        "count": 20
+      },
+      {
+        "id": 71969,
+        "emoji": "😀",
+        "count": 14
+      },
+      {
+        "id": 8787,
+        "emoji": "❤️",
+        "count": 10
+      },
+      {
+        "id": 56094,
+        "emoji": "🥹",
+        "count": 3
+      },
+      {
+        "id": 4661,
+        "emoji": "😁",
+        "count": 6
+      }
+    ]
+  },
+  {
+    "id": 80709,
+    "name": "전지현",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/80709/600/400",
+    "createdAt": "2023-10-26T20:03:42Z",
+    "messageCount": 2,
+    "recentMessages": [
+      {
+        "id": 29605,
+        "recipientId": 80709,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/86/200/200",
+        "relationship": "친구",
+        "content": "전지현님의 메세지 내용 27",
+        "font": "Pretendard",
+        "createdAt": "2023-07-06T04:37:31Z"
+      },
+      {
+        "id": 50599,
+        "recipientId": 80709,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/117/200/200",
+        "relationship": "가족",
+        "content": "박서준님의 메세지 내용 12",
+        "font": "Pretendard",
+        "createdAt": "2023-06-10T14:25:31Z"
+      }
+    ],
+    "reactionCount": 53,
+    "topReactions": [
+      {
+        "id": 33992,
+        "emoji": "🎉",
+        "count": 13
+      }
+    ]
+  },
+  {
+    "id": 625,
+    "name": "전지현",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/625/600/400",
+    "createdAt": "2023-12-14T02:55:26Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 59897,
+        "recipientId": 625,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/411/200/200",
+        "relationship": "동료",
+        "content": "전지현님의 메세지 내용 99",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-03-12T00:35:57Z"
+      },
+      {
+        "id": 53736,
+        "recipientId": 625,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/411/200/200",
+        "relationship": "친구",
+        "content": "이병헌님의 메세지 내용 98",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-06-06T17:47:12Z"
+      },
+      {
+        "id": 9641,
+        "recipientId": 625,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/498/200/200",
+        "relationship": "지인",
+        "content": "김하은님의 메세지 내용 66",
+        "font": "Pretendard",
+        "createdAt": "2023-07-05T12:51:17Z"
+      }
+    ],
+    "reactionCount": 66,
+    "topReactions": [
+      {
+        "id": 36713,
+        "emoji": "❤️",
+        "count": 2
+      },
+      {
+        "id": 89567,
+        "emoji": "🥹",
+        "count": 2
+      },
+      {
+        "id": 98915,
+        "emoji": "🥹",
+        "count": 7
+      },
+      {
+        "id": 6789,
+        "emoji": "😁",
+        "count": 10
+      }
+    ]
+  },
+  {
+    "id": 23417,
+    "name": "최민수",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/23417/600/400",
+    "createdAt": "2023-09-15T03:16:30Z",
+    "messageCount": 6,
+    "recentMessages": [
+      {
+        "id": 82536,
+        "recipientId": 23417,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/236/200/200",
+        "relationship": "동료",
+        "content": "정우성님의 메세지 내용 76",
+        "font": "Roboto",
+        "createdAt": "2023-03-05T16:15:27Z"
+      },
+      {
+        "id": 22812,
+        "recipientId": 23417,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/441/200/200",
+        "relationship": "친구",
+        "content": "현빈님의 메세지 내용 10",
+        "font": "Pretendard",
+        "createdAt": "2023-07-09T04:44:48Z"
+      },
+      {
+        "id": 53607,
+        "recipientId": 23417,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/402/200/200",
+        "relationship": "지인",
+        "content": "이병헌님의 메세지 내용 96",
+        "font": "Noto Sans",
+        "createdAt": "2023-06-28T04:25:20Z"
+      }
+    ],
+    "reactionCount": 42,
+    "topReactions": [
+      {
+        "id": 2457,
+        "emoji": "👍",
+        "count": 10
+      },
+      {
+        "id": 86246,
+        "emoji": "❤️",
+        "count": 2
+      },
+      {
+        "id": 54698,
+        "emoji": "❤️",
+        "count": 7
+      },
+      {
+        "id": 72375,
+        "emoji": "😀",
+        "count": 2
+      },
+      {
+        "id": 7835,
+        "emoji": "😁",
+        "count": 1
+      }
+    ]
+  },
+  {
+    "id": 60892,
+    "name": "최민수",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/60892/600/400",
+    "createdAt": "2023-11-21T04:18:37Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 18337,
+        "recipientId": 60892,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/99/200/200",
+        "relationship": "동료",
+        "content": "송혜교님의 메세지 내용 47",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-04-10T16:57:19Z"
+      },
+      {
+        "id": 88221,
+        "recipientId": 60892,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/477/200/200",
+        "relationship": "친구",
+        "content": "현빈님의 메세지 내용 35",
+        "font": "Noto Sans",
+        "createdAt": "2023-05-10T18:53:49Z"
+      },
+      {
+        "id": 97322,
+        "recipientId": 60892,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/146/200/200",
+        "relationship": "가족",
+        "content": "한지민님의 메세지 내용 17",
+        "font": "Pretendard",
+        "createdAt": "2023-09-10T05:52:40Z"
+      }
+    ],
+    "reactionCount": 51,
+    "topReactions": [
+      {
+        "id": 60510,
+        "emoji": "😁",
+        "count": 5
+      },
+      {
+        "id": 183,
+        "emoji": "😀",
+        "count": 12
+      },
+      {
+        "id": 70387,
+        "emoji": "❤️",
+        "count": 5
+      },
+      {
+        "id": 5940,
+        "emoji": "🥹",
+        "count": 20
+      },
+      {
+        "id": 69316,
+        "emoji": "🎉",
+        "count": 2
+      }
+    ]
+  },
+  {
+    "id": 77216,
+    "name": "송혜교",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-03-12T09:36:47Z",
+    "messageCount": 5,
+    "recentMessages": [
+      {
+        "id": 20785,
+        "recipientId": 77216,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/163/200/200",
+        "relationship": "동료",
+        "content": "송혜교님의 메세지 내용 58",
+        "font": "Noto Sans",
+        "createdAt": "2023-07-17T16:37:49Z"
+      },
+      {
+        "id": 1433,
+        "recipientId": 77216,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/379/200/200",
+        "relationship": "가족",
+        "content": "한지민님의 메세지 내용 21",
+        "font": "Pretendard",
+        "createdAt": "2023-08-26T07:59:50Z"
+      },
+      {
+        "id": 8255,
+        "recipientId": 77216,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/492/200/200",
+        "relationship": "가족",
+        "content": "현빈님의 메세지 내용 85",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-11-20T17:06:48Z"
+      }
+    ],
+    "reactionCount": 6,
+    "topReactions": [
+      {
+        "id": 52593,
+        "emoji": "🥹",
+        "count": 1
+      },
+      {
+        "id": 49827,
+        "emoji": "🎉",
+        "count": 12
+      },
+      {
+        "id": 3837,
+        "emoji": "👍",
+        "count": 9
+      }
+    ]
+  },
+  {
+    "id": 48647,
+    "name": "현빈",
+    "backgroundColor": "blue",
+    "backgroundImageURL": null,
+    "createdAt": "2023-11-16T13:18:03Z",
+    "messageCount": 7,
+    "recentMessages": [
+      {
+        "id": 76625,
+        "recipientId": 48647,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/256/200/200",
+        "relationship": "가족",
+        "content": "이병헌님의 메세지 내용 98",
+        "font": "Pretendard",
+        "createdAt": "2023-03-21T02:42:08Z"
+      },
+      {
+        "id": 43638,
+        "recipientId": 48647,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/410/200/200",
+        "relationship": "가족",
+        "content": "현빈님의 메세지 내용 41",
+        "font": "Noto Sans",
+        "createdAt": "2023-04-24T22:09:02Z"
+      },
+      {
+        "id": 26804,
+        "recipientId": 48647,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/347/200/200",
+        "relationship": "친구",
+        "content": "전지현님의 메세지 내용 88",
+        "font": "Pretendard",
+        "createdAt": "2024-01-08T19:39:50Z"
+      }
+    ],
+    "reactionCount": 28,
+    "topReactions": [
+      {
+        "id": 38782,
+        "emoji": "🎉",
+        "count": 10
+      },
+      {
+        "id": 30497,
+        "emoji": "❤️",
+        "count": 20
+      },
+      {
+        "id": 65578,
+        "emoji": "😀",
+        "count": 11
+      },
+      {
+        "id": 54351,
+        "emoji": "❤️",
+        "count": 2
+      }
+    ]
+  },
+  {
+    "id": 7110,
+    "name": "전지현",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-10-20T12:41:27Z",
+    "messageCount": 10,
+    "recentMessages": [
+      {
+        "id": 90888,
+        "recipientId": 7110,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/19/200/200",
+        "relationship": "지인",
+        "content": "이병헌님의 메세지 내용 42",
+        "font": "Roboto",
+        "createdAt": "2023-09-16T18:15:50Z"
+      },
+      {
+        "id": 11380,
+        "recipientId": 7110,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/373/200/200",
+        "relationship": "동료",
+        "content": "이영준님의 메세지 내용 42",
+        "font": "Roboto",
+        "createdAt": "2023-04-14T16:26:10Z"
+      },
+      {
+        "id": 26575,
+        "recipientId": 7110,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/184/200/200",
+        "relationship": "가족",
+        "content": "송혜교님의 메세지 내용 65",
+        "font": "Pretendard",
+        "createdAt": "2023-07-31T19:38:34Z"
+      }
+    ],
+    "reactionCount": 75,
+    "topReactions": [
+      {
+        "id": 71539,
+        "emoji": "👍",
+        "count": 15
+      },
+      {
+        "id": 86386,
+        "emoji": "❤️",
+        "count": 4
+      },
+      {
+        "id": 81736,
+        "emoji": "🎉",
+        "count": 12
+      },
+      {
+        "id": 63021,
+        "emoji": "❤️",
+        "count": 13
+      }
+    ]
+  },
+  {
+    "id": 45995,
+    "name": "이영준",
+    "backgroundColor": "blue",
+    "backgroundImageURL": null,
+    "createdAt": "2023-09-30T01:37:16Z",
+    "messageCount": 9,
+    "recentMessages": [
+      {
+        "id": 62949,
+        "recipientId": 45995,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/270/200/200",
+        "relationship": "가족",
+        "content": "김하은님의 메세지 내용 52",
+        "font": "Pretendard",
+        "createdAt": "2023-12-26T22:51:46Z"
+      },
+      {
+        "id": 54691,
+        "recipientId": 45995,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/148/200/200",
+        "relationship": "가족",
+        "content": "전지현님의 메세지 내용 77",
+        "font": "Pretendard",
+        "createdAt": "2023-12-25T22:42:52Z"
+      },
+      {
+        "id": 41428,
+        "recipientId": 45995,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/13/200/200",
+        "relationship": "가족",
+        "content": "최민수님의 메세지 내용 11",
+        "font": "Roboto",
+        "createdAt": "2023-04-15T01:57:19Z"
+      }
+    ],
+    "reactionCount": 52,
+    "topReactions": [
+      {
+        "id": 21041,
+        "emoji": "❤️",
+        "count": 3
+      },
+      {
+        "id": 81901,
+        "emoji": "🎉",
+        "count": 20
+      },
+      {
+        "id": 3660,
+        "emoji": "🥹",
+        "count": 7
+      }
+    ]
+  },
+  {
+    "id": 75973,
+    "name": "이병헌",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/75973/600/400",
+    "createdAt": "2023-04-29T23:14:33Z",
+    "messageCount": 6,
+    "recentMessages": [
+      {
+        "id": 85401,
+        "recipientId": 75973,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/269/200/200",
+        "relationship": "동료",
+        "content": "이병헌님의 메세지 내용 90",
+        "font": "Noto Sans",
+        "createdAt": "2023-11-12T05:17:44Z"
+      },
+      {
+        "id": 35095,
+        "recipientId": 75973,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/390/200/200",
+        "relationship": "친구",
+        "content": "송혜교님의 메세지 내용 74",
+        "font": "Roboto",
+        "createdAt": "2023-10-05T14:15:30Z"
+      },
+      {
+        "id": 99991,
+        "recipientId": 75973,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/240/200/200",
+        "relationship": "지인",
+        "content": "김하은님의 메세지 내용 17",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-09-17T18:51:27Z"
+      }
+    ],
+    "reactionCount": 27,
+    "topReactions": [
+      {
+        "id": 98483,
+        "emoji": "🥹",
+        "count": 5
+      },
+      {
+        "id": 73979,
+        "emoji": "🥹",
+        "count": 7
+      },
+      {
+        "id": 14149,
+        "emoji": "🥹",
+        "count": 4
+      },
+      {
+        "id": 73714,
+        "emoji": "😁",
+        "count": 11
+      }
+    ]
+  },
+  {
+    "id": 61839,
+    "name": "최민수",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/61839/600/400",
+    "createdAt": "2023-08-11T13:58:13Z",
+    "messageCount": 10,
+    "recentMessages": [
+      {
+        "id": 76692,
+        "recipientId": 61839,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/257/200/200",
+        "relationship": "지인",
+        "content": "정우성님의 메세지 내용 71",
+        "font": "Roboto",
+        "createdAt": "2023-04-13T09:59:09Z"
+      },
+      {
+        "id": 94381,
+        "recipientId": 61839,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/344/200/200",
+        "relationship": "가족",
+        "content": "이영준님의 메세지 내용 63",
+        "font": "Noto Sans",
+        "createdAt": "2023-03-28T05:18:11Z"
+      },
+      {
+        "id": 56587,
+        "recipientId": 61839,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/194/200/200",
+        "relationship": "지인",
+        "content": "최민수님의 메세지 내용 92",
+        "font": "Pretendard",
+        "createdAt": "2023-02-13T15:44:01Z"
+      }
+    ],
+    "reactionCount": 54,
+    "topReactions": [
+      {
+        "id": 84273,
+        "emoji": "🥹",
+        "count": 18
+      },
+      {
+        "id": 67980,
+        "emoji": "😀",
+        "count": 19
+      },
+      {
+        "id": 57293,
+        "emoji": "🥹",
+        "count": 9
+      }
+    ]
+  },
+  {
+    "id": 17028,
+    "name": "박서준",
+    "backgroundColor": "green",
+    "backgroundImageURL": null,
+    "createdAt": "2023-10-12T01:14:00Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 80146,
+        "recipientId": 17028,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/273/200/200",
+        "relationship": "가족",
+        "content": "정우성님의 메세지 내용 50",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-08-20T23:27:16Z"
+      },
+      {
+        "id": 45410,
+        "recipientId": 17028,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/371/200/200",
+        "relationship": "지인",
+        "content": "박서준님의 메세지 내용 22",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-03-05T19:49:12Z"
+      },
+      {
+        "id": 72881,
+        "recipientId": 17028,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/471/200/200",
+        "relationship": "친구",
+        "content": "전지현님의 메세지 내용 45",
+        "font": "Nanum Gothic",
+        "createdAt": "2024-01-21T18:46:39Z"
+      }
+    ],
+    "reactionCount": 66,
+    "topReactions": [
+      {
+        "id": 48674,
+        "emoji": "😁",
+        "count": 16
+      },
+      {
+        "id": 8548,
+        "emoji": "😀",
+        "count": 6
+      },
+      {
+        "id": 43006,
+        "emoji": "😁",
+        "count": 15
+      },
+      {
+        "id": 6573,
+        "emoji": "😁",
+        "count": 6
+      },
+      {
+        "id": 57200,
+        "emoji": "😀",
+        "count": 1
+      }
+    ]
+  },
+  {
+    "id": 58041,
+    "name": "최민수",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/58041/600/400",
+    "createdAt": "2023-04-05T19:24:00Z",
+    "messageCount": 7,
+    "recentMessages": [
+      {
+        "id": 44629,
+        "recipientId": 58041,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/385/200/200",
+        "relationship": "가족",
+        "content": "한지민님의 메세지 내용 51",
+        "font": "Pretendard",
+        "createdAt": "2024-01-26T15:26:36Z"
+      },
+      {
+        "id": 78779,
+        "recipientId": 58041,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/86/200/200",
+        "relationship": "가족",
+        "content": "정우성님의 메세지 내용 54",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-04-15T11:17:51Z"
+      },
+      {
+        "id": 48497,
+        "recipientId": 58041,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/17/200/200",
+        "relationship": "동료",
+        "content": "김하은님의 메세지 내용 56",
+        "font": "Roboto",
+        "createdAt": "2023-04-05T00:53:28Z"
+      }
+    ],
+    "reactionCount": 48,
+    "topReactions": [
+      {
+        "id": 214,
+        "emoji": "👍",
+        "count": 3
+      },
+      {
+        "id": 16801,
+        "emoji": "😀",
+        "count": 1
+      },
+      {
+        "id": 64372,
+        "emoji": "❤️",
+        "count": 18
+      },
+      {
+        "id": 4933,
+        "emoji": "🎉",
+        "count": 4
+      }
+    ]
+  },
+  {
+    "id": 75495,
+    "name": "현빈",
+    "backgroundColor": "green",
+    "backgroundImageURL": null,
+    "createdAt": "2023-05-01T13:49:11Z",
+    "messageCount": 9,
+    "recentMessages": [
+      {
+        "id": 43732,
+        "recipientId": 75495,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/7/200/200",
+        "relationship": "지인",
+        "content": "박서준님의 메세지 내용 78",
+        "font": "Roboto",
+        "createdAt": "2023-02-07T09:31:01Z"
+      },
+      {
+        "id": 49379,
+        "recipientId": 75495,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/332/200/200",
+        "relationship": "가족",
+        "content": "김하은님의 메세지 내용 21",
+        "font": "Roboto",
+        "createdAt": "2024-02-05T01:17:08Z"
+      },
+      {
+        "id": 71393,
+        "recipientId": 75495,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/126/200/200",
+        "relationship": "가족",
+        "content": "이영준님의 메세지 내용 48",
+        "font": "Noto Sans",
+        "createdAt": "2023-01-26T06:27:51Z"
+      }
+    ],
+    "reactionCount": 55,
+    "topReactions": [
+      {
+        "id": 1802,
+        "emoji": "😀",
+        "count": 10
+      },
+      {
+        "id": 94631,
+        "emoji": "🎉",
+        "count": 17
+      },
+      {
+        "id": 42577,
+        "emoji": "❤️",
+        "count": 6
+      },
+      {
+        "id": 83907,
+        "emoji": "🎉",
+        "count": 6
+      }
+    ]
+  },
+  {
+    "id": 87390,
+    "name": "이영준",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2023-05-14T14:22:59Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 78211,
+        "recipientId": 87390,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/382/200/200",
+        "relationship": "동료",
+        "content": "김하은님의 메세지 내용 5",
+        "font": "Noto Sans",
+        "createdAt": "2023-09-05T09:24:06Z"
+      },
+      {
+        "id": 28440,
+        "recipientId": 87390,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/360/200/200",
+        "relationship": "가족",
+        "content": "송혜교님의 메세지 내용 77",
+        "font": "Pretendard",
+        "createdAt": "2023-12-12T04:25:04Z"
+      },
+      {
+        "id": 82273,
+        "recipientId": 87390,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/17/200/200",
+        "relationship": "지인",
+        "content": "이영준님의 메세지 내용 50",
+        "font": "Noto Sans",
+        "createdAt": "2024-01-03T08:25:32Z"
+      }
+    ],
+    "reactionCount": 6,
+    "topReactions": [
+      {
+        "id": 14584,
+        "emoji": "👍",
+        "count": 16
+      },
+      {
+        "id": 64130,
+        "emoji": "🎉",
+        "count": 19
+      },
+      {
+        "id": 98800,
+        "emoji": "😀",
+        "count": 20
+      },
+      {
+        "id": 93562,
+        "emoji": "😁",
+        "count": 13
+      }
+    ]
+  },
+  {
+    "id": 38320,
+    "name": "송혜교",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/38320/600/400",
+    "createdAt": "2023-08-11T20:43:38Z",
+    "messageCount": 6,
+    "recentMessages": [
+      {
+        "id": 37599,
+        "recipientId": 38320,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/36/200/200",
+        "relationship": "친구",
+        "content": "송혜교님의 메세지 내용 46",
+        "font": "Noto Sans",
+        "createdAt": "2023-10-23T14:59:02Z"
+      },
+      {
+        "id": 29674,
+        "recipientId": 38320,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/441/200/200",
+        "relationship": "가족",
+        "content": "최민수님의 메세지 내용 48",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-02-06T21:23:13Z"
+      },
+      {
+        "id": 32572,
+        "recipientId": 38320,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/197/200/200",
+        "relationship": "가족",
+        "content": "박서준님의 메세지 내용 38",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-12-03T06:30:07Z"
+      }
+    ],
+    "reactionCount": 24,
+    "topReactions": [
+      {
+        "id": 85440,
+        "emoji": "😀",
+        "count": 4
+      },
+      {
+        "id": 94784,
+        "emoji": "❤️",
+        "count": 3
+      },
+      {
+        "id": 65361,
+        "emoji": "👍",
+        "count": 12
+      },
+      {
+        "id": 74494,
+        "emoji": "🥹",
+        "count": 2
+      },
+      {
+        "id": 20433,
+        "emoji": "🥹",
+        "count": 2
+      }
+    ]
+  },
+  {
+    "id": 35660,
+    "name": "이영준",
+    "backgroundColor": "green",
+    "backgroundImageURL": null,
+    "createdAt": "2023-12-15T20:22:31Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 94600,
+        "recipientId": 35660,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/203/200/200",
+        "relationship": "지인",
+        "content": "한지민님의 메세지 내용 33",
+        "font": "Roboto",
+        "createdAt": "2023-02-08T07:18:43Z"
+      },
+      {
+        "id": 55920,
+        "recipientId": 35660,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/386/200/200",
+        "relationship": "동료",
+        "content": "박서준님의 메세지 내용 98",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-09-22T08:00:11Z"
+      },
+      {
+        "id": 18674,
+        "recipientId": 35660,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/308/200/200",
+        "relationship": "친구",
+        "content": "송혜교님의 메세지 내용 9",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-11-03T06:40:58Z"
+      }
+    ],
+    "reactionCount": 65,
+    "topReactions": [
+      {
+        "id": 4983,
+        "emoji": "😀",
+        "count": 20
+      },
+      {
+        "id": 91060,
+        "emoji": "❤️",
+        "count": 2
+      }
+    ]
+  },
+  {
+    "id": 32314,
+    "name": "이병헌",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2023-06-09T07:16:23Z",
+    "messageCount": 9,
+    "recentMessages": [
+      {
+        "id": 89356,
+        "recipientId": 32314,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/104/200/200",
+        "relationship": "동료",
+        "content": "현빈님의 메세지 내용 25",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-12-02T19:32:52Z"
+      },
+      {
+        "id": 10034,
+        "recipientId": 32314,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/288/200/200",
+        "relationship": "친구",
+        "content": "이병헌님의 메세지 내용 22",
+        "font": "Pretendard",
+        "createdAt": "2023-09-14T13:27:24Z"
+      },
+      {
+        "id": 75054,
+        "recipientId": 32314,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/483/200/200",
+        "relationship": "가족",
+        "content": "김하은님의 메세지 내용 25",
+        "font": "Pretendard",
+        "createdAt": "2023-03-09T17:03:28Z"
+      }
+    ],
+    "reactionCount": 59,
+    "topReactions": [
+      {
+        "id": 58698,
+        "emoji": "😀",
+        "count": 13
+      }
+    ]
+  },
+  {
+    "id": 43043,
+    "name": "송혜교",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/43043/600/400",
+    "createdAt": "2023-02-22T13:08:51Z",
+    "messageCount": 9,
+    "recentMessages": [
+      {
+        "id": 47574,
+        "recipientId": 43043,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/63/200/200",
+        "relationship": "친구",
+        "content": "현빈님의 메세지 내용 2",
+        "font": "Noto Sans",
+        "createdAt": "2023-08-29T05:01:20Z"
+      },
+      {
+        "id": 38817,
+        "recipientId": 43043,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/439/200/200",
+        "relationship": "지인",
+        "content": "최민수님의 메세지 내용 21",
+        "font": "Noto Sans",
+        "createdAt": "2023-04-16T03:40:54Z"
+      },
+      {
+        "id": 16978,
+        "recipientId": 43043,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/425/200/200",
+        "relationship": "동료",
+        "content": "김하은님의 메세지 내용 17",
+        "font": "Pretendard",
+        "createdAt": "2023-11-16T09:47:54Z"
+      }
+    ],
+    "reactionCount": 16,
+    "topReactions": [
+      {
+        "id": 7801,
+        "emoji": "😁",
+        "count": 12
+      },
+      {
+        "id": 58961,
+        "emoji": "❤️",
+        "count": 16
+      },
+      {
+        "id": 59283,
+        "emoji": "🥹",
+        "count": 5
+      }
+    ]
+  },
+  {
+    "id": 45937,
+    "name": "김하은",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2024-01-22T12:24:12Z",
+    "messageCount": 5,
+    "recentMessages": [
+      {
+        "id": 5896,
+        "recipientId": 45937,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/38/200/200",
+        "relationship": "가족",
+        "content": "한지민님의 메세지 내용 44",
+        "font": "Pretendard",
+        "createdAt": "2023-12-13T13:33:23Z"
+      },
+      {
+        "id": 49858,
+        "recipientId": 45937,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/367/200/200",
+        "relationship": "가족",
+        "content": "한지민님의 메세지 내용 7",
+        "font": "Roboto",
+        "createdAt": "2023-09-15T13:57:29Z"
+      },
+      {
+        "id": 49667,
+        "recipientId": 45937,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/407/200/200",
+        "relationship": "가족",
+        "content": "송혜교님의 메세지 내용 34",
+        "font": "Noto Sans",
+        "createdAt": "2023-07-28T02:57:58Z"
+      }
+    ],
+    "reactionCount": 37,
+    "topReactions": [
+      {
+        "id": 11248,
+        "emoji": "❤️",
+        "count": 3
+      }
+    ]
+  },
+  {
+    "id": 63219,
+    "name": "이영준",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/63219/600/400",
+    "createdAt": "2023-06-12T11:10:34Z",
+    "messageCount": 7,
+    "recentMessages": [
+      {
+        "id": 75822,
+        "recipientId": 63219,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/119/200/200",
+        "relationship": "친구",
+        "content": "최민수님의 메세지 내용 59",
+        "font": "Roboto",
+        "createdAt": "2023-04-03T20:37:21Z"
+      },
+      {
+        "id": 49459,
+        "recipientId": 63219,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/181/200/200",
+        "relationship": "친구",
+        "content": "한지민님의 메세지 내용 83",
+        "font": "Pretendard",
+        "createdAt": "2023-11-12T23:18:57Z"
+      },
+      {
+        "id": 50489,
+        "recipientId": 63219,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/11/200/200",
+        "relationship": "친구",
+        "content": "이병헌님의 메세지 내용 77",
+        "font": "Noto Sans",
+        "createdAt": "2023-11-27T08:16:32Z"
+      }
+    ],
+    "reactionCount": 17,
+    "topReactions": [
+      {
+        "id": 78228,
+        "emoji": "🥹",
+        "count": 4
+      },
+      {
+        "id": 93441,
+        "emoji": "🥹",
+        "count": 10
+      }
+    ]
+  },
+  {
+    "id": 32218,
+    "name": "이병헌",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-07-22T22:33:51Z",
+    "messageCount": 5,
+    "recentMessages": [
+      {
+        "id": 68615,
+        "recipientId": 32218,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/279/200/200",
+        "relationship": "가족",
+        "content": "이영준님의 메세지 내용 35",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-01-19T15:23:35Z"
+      },
+      {
+        "id": 42475,
+        "recipientId": 32218,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/15/200/200",
+        "relationship": "친구",
+        "content": "정우성님의 메세지 내용 9",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-10-23T06:35:16Z"
+      },
+      {
+        "id": 84692,
+        "recipientId": 32218,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/335/200/200",
+        "relationship": "친구",
+        "content": "현빈님의 메세지 내용 43",
+        "font": "Noto Sans",
+        "createdAt": "2023-06-03T21:56:10Z"
+      }
+    ],
+    "reactionCount": 47,
+    "topReactions": [
+      {
+        "id": 88844,
+        "emoji": "🎉",
+        "count": 16
+      },
+      {
+        "id": 58724,
+        "emoji": "👍",
+        "count": 19
+      },
+      {
+        "id": 26471,
+        "emoji": "👍",
+        "count": 5
+      },
+      {
+        "id": 39423,
+        "emoji": "😁",
+        "count": 15
+      },
+      {
+        "id": 68714,
+        "emoji": "👍",
+        "count": 6
+      }
+    ]
+  },
+  {
+    "id": 80991,
+    "name": "정우성",
+    "backgroundColor": "blue",
+    "backgroundImageURL": null,
+    "createdAt": "2023-10-23T18:52:08Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 84011,
+        "recipientId": 80991,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/258/200/200",
+        "relationship": "지인",
+        "content": "전지현님의 메세지 내용 18",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-06-07T13:22:14Z"
+      },
+      {
+        "id": 35058,
+        "recipientId": 80991,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/223/200/200",
+        "relationship": "친구",
+        "content": "최민수님의 메세지 내용 70",
+        "font": "Pretendard",
+        "createdAt": "2023-01-22T04:44:31Z"
+      },
+      {
+        "id": 9223,
+        "recipientId": 80991,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/474/200/200",
+        "relationship": "친구",
+        "content": "이영준님의 메세지 내용 97",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-03-05T23:34:32Z"
+      }
+    ],
+    "reactionCount": 2,
+    "topReactions": [
+      {
+        "id": 42141,
+        "emoji": "👍",
+        "count": 19
+      }
+    ]
+  },
+  {
+    "id": 1341,
+    "name": "송혜교",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2023-07-12T16:03:05Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 3046,
+        "recipientId": 1341,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/167/200/200",
+        "relationship": "친구",
+        "content": "현빈님의 메세지 내용 93",
+        "font": "Roboto",
+        "createdAt": "2023-11-10T18:21:23Z"
+      },
+      {
+        "id": 47841,
+        "recipientId": 1341,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/186/200/200",
+        "relationship": "지인",
+        "content": "박서준님의 메세지 내용 51",
+        "font": "Noto Sans",
+        "createdAt": "2023-07-15T12:17:59Z"
+      },
+      {
+        "id": 24988,
+        "recipientId": 1341,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/423/200/200",
+        "relationship": "친구",
+        "content": "이병헌님의 메세지 내용 64",
+        "font": "Roboto",
+        "createdAt": "2023-01-06T05:53:05Z"
+      }
+    ],
+    "reactionCount": 95,
+    "topReactions": [
+      {
+        "id": 39502,
+        "emoji": "🎉",
+        "count": 11
+      }
+    ]
+  },
+  {
+    "id": 6051,
+    "name": "정우성",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/6051/600/400",
+    "createdAt": "2023-11-10T15:09:44Z",
+    "messageCount": 6,
+    "recentMessages": [
+      {
+        "id": 7288,
+        "recipientId": 6051,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/156/200/200",
+        "relationship": "지인",
+        "content": "송혜교님의 메세지 내용 39",
+        "font": "Noto Sans",
+        "createdAt": "2023-07-23T06:22:45Z"
+      },
+      {
+        "id": 13782,
+        "recipientId": 6051,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/433/200/200",
+        "relationship": "친구",
+        "content": "정우성님의 메세지 내용 100",
+        "font": "Pretendard",
+        "createdAt": "2023-02-11T22:46:47Z"
+      },
+      {
+        "id": 33148,
+        "recipientId": 6051,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/442/200/200",
+        "relationship": "동료",
+        "content": "한지민님의 메세지 내용 35",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-08-13T00:23:31Z"
+      }
+    ],
+    "reactionCount": 87,
+    "topReactions": [
+      {
+        "id": 1723,
+        "emoji": "🎉",
+        "count": 3
+      },
+      {
+        "id": 7654,
+        "emoji": "😀",
+        "count": 8
+      },
+      {
+        "id": 29263,
+        "emoji": "😀",
+        "count": 4
+      }
+    ]
+  },
+  {
+    "id": 93438,
+    "name": "이병헌",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/93438/600/400",
+    "createdAt": "2023-04-02T11:00:53Z",
+    "messageCount": 3,
+    "recentMessages": [
+      {
+        "id": 66472,
+        "recipientId": 93438,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/333/200/200",
+        "relationship": "가족",
+        "content": "전지현님의 메세지 내용 94",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-03-26T16:14:53Z"
+      },
+      {
+        "id": 6156,
+        "recipientId": 93438,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/109/200/200",
+        "relationship": "동료",
+        "content": "이병헌님의 메세지 내용 59",
+        "font": "Noto Sans",
+        "createdAt": "2023-01-24T10:30:39Z"
+      },
+      {
+        "id": 45844,
+        "recipientId": 93438,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/182/200/200",
+        "relationship": "동료",
+        "content": "박서준님의 메세지 내용 33",
+        "font": "Noto Sans",
+        "createdAt": "2023-11-23T09:30:34Z"
+      }
+    ],
+    "reactionCount": 99,
+    "topReactions": [
+      {
+        "id": 19288,
+        "emoji": "😁",
+        "count": 11
+      }
+    ]
+  },
+  {
+    "id": 44334,
+    "name": "이병헌",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/44334/600/400",
+    "createdAt": "2023-12-30T01:42:47Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 42994,
+        "recipientId": 44334,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/465/200/200",
+        "relationship": "동료",
+        "content": "정우성님의 메세지 내용 81",
+        "font": "Roboto",
+        "createdAt": "2023-02-14T10:13:11Z"
+      },
+      {
+        "id": 56130,
+        "recipientId": 44334,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/227/200/200",
+        "relationship": "동료",
+        "content": "이영준님의 메세지 내용 25",
+        "font": "Roboto",
+        "createdAt": "2023-02-02T18:27:08Z"
+      },
+      {
+        "id": 41595,
+        "recipientId": 44334,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/64/200/200",
+        "relationship": "친구",
+        "content": "전지현님의 메세지 내용 86",
+        "font": "Pretendard",
+        "createdAt": "2023-01-18T09:46:31Z"
+      }
+    ],
+    "reactionCount": 87,
+    "topReactions": [
+      {
+        "id": 37061,
+        "emoji": "👍",
+        "count": 6
+      },
+      {
+        "id": 2287,
+        "emoji": "👍",
+        "count": 11
+      },
+      {
+        "id": 45099,
+        "emoji": "😀",
+        "count": 12
+      },
+      {
+        "id": 90256,
+        "emoji": "😁",
+        "count": 7
+      },
+      {
+        "id": 99885,
+        "emoji": "👍",
+        "count": 8
+      },
+      {
+        "id": 76279,
+        "emoji": "❤️",
+        "count": 12
+      }
+    ]
+  },
+  {
+    "id": 82732,
+    "name": "최민수",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2023-01-17T04:31:54Z",
+    "messageCount": 9,
+    "recentMessages": [
+      {
+        "id": 97297,
+        "recipientId": 82732,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/444/200/200",
+        "relationship": "가족",
+        "content": "송혜교님의 메세지 내용 78",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-02-09T10:16:50Z"
+      },
+      {
+        "id": 71861,
+        "recipientId": 82732,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/498/200/200",
+        "relationship": "동료",
+        "content": "박서준님의 메세지 내용 55",
+        "font": "Roboto",
+        "createdAt": "2023-03-15T16:30:09Z"
+      },
+      {
+        "id": 74035,
+        "recipientId": 82732,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/36/200/200",
+        "relationship": "가족",
+        "content": "박서준님의 메세지 내용 23",
+        "font": "Roboto",
+        "createdAt": "2024-01-21T23:20:59Z"
+      }
+    ],
+    "reactionCount": 70,
+    "topReactions": [
+      {
+        "id": 17950,
+        "emoji": "🥹",
+        "count": 20
+      }
+    ]
+  },
+  {
+    "id": 44928,
+    "name": "이병헌",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-11-24T12:12:26Z",
+    "messageCount": 1,
+    "recentMessages": [
+      {
+        "id": 76155,
+        "recipientId": 44928,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/40/200/200",
+        "relationship": "동료",
+        "content": "전지현님의 메세지 내용 88",
+        "font": "Pretendard",
+        "createdAt": "2023-03-16T10:54:28Z"
+      }
+    ],
+    "reactionCount": 8,
+    "topReactions": [
+      {
+        "id": 82489,
+        "emoji": "🥹",
+        "count": 7
+      },
+      {
+        "id": 41836,
+        "emoji": "🥹",
+        "count": 7
+      },
+      {
+        "id": 64846,
+        "emoji": "❤️",
+        "count": 9
+      },
+      {
+        "id": 50727,
+        "emoji": "❤️",
+        "count": 14
+      }
+    ]
+  },
+  {
+    "id": 94539,
+    "name": "최민수",
+    "backgroundColor": "green",
+    "backgroundImageURL": null,
+    "createdAt": "2024-01-11T07:24:22Z",
+    "messageCount": 3,
+    "recentMessages": [
+      {
+        "id": 31761,
+        "recipientId": 94539,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/62/200/200",
+        "relationship": "가족",
+        "content": "이병헌님의 메세지 내용 53",
+        "font": "Pretendard",
+        "createdAt": "2023-04-17T18:23:36Z"
+      },
+      {
+        "id": 6032,
+        "recipientId": 94539,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/230/200/200",
+        "relationship": "가족",
+        "content": "송혜교님의 메세지 내용 76",
+        "font": "Noto Sans",
+        "createdAt": "2023-03-28T17:44:01Z"
+      },
+      {
+        "id": 79432,
+        "recipientId": 94539,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/178/200/200",
+        "relationship": "동료",
+        "content": "정우성님의 메세지 내용 36",
+        "font": "Roboto",
+        "createdAt": "2023-05-31T20:44:54Z"
+      }
+    ],
+    "reactionCount": 92,
+    "topReactions": [
+      {
+        "id": 73214,
+        "emoji": "👍",
+        "count": 14
+      },
+      {
+        "id": 314,
+        "emoji": "😀",
+        "count": 20
+      }
+    ]
+  },
+  {
+    "id": 91720,
+    "name": "한지민",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2023-12-15T09:41:38Z",
+    "messageCount": 6,
+    "recentMessages": [
+      {
+        "id": 44369,
+        "recipientId": 91720,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/306/200/200",
+        "relationship": "동료",
+        "content": "전지현님의 메세지 내용 1",
+        "font": "Roboto",
+        "createdAt": "2023-05-14T15:14:24Z"
+      },
+      {
+        "id": 9488,
+        "recipientId": 91720,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/61/200/200",
+        "relationship": "지인",
+        "content": "한지민님의 메세지 내용 100",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-02-20T18:02:40Z"
+      },
+      {
+        "id": 44680,
+        "recipientId": 91720,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/40/200/200",
+        "relationship": "친구",
+        "content": "한지민님의 메세지 내용 57",
+        "font": "Roboto",
+        "createdAt": "2023-09-07T19:51:33Z"
+      }
+    ],
+    "reactionCount": 73,
+    "topReactions": [
+      {
+        "id": 49624,
+        "emoji": "😁",
+        "count": 6
+      },
+      {
+        "id": 69914,
+        "emoji": "😁",
+        "count": 17
+      },
+      {
+        "id": 12300,
+        "emoji": "👍",
+        "count": 16
+      },
+      {
+        "id": 26416,
+        "emoji": "🎉",
+        "count": 12
+      }
+    ]
+  },
+  {
+    "id": 35251,
+    "name": "정우성",
+    "backgroundColor": "blue",
+    "backgroundImageURL": null,
+    "createdAt": "2023-12-25T20:29:41Z",
+    "messageCount": 10,
+    "recentMessages": [
+      {
+        "id": 1090,
+        "recipientId": 35251,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/153/200/200",
+        "relationship": "동료",
+        "content": "최민수님의 메세지 내용 98",
+        "font": "Pretendard",
+        "createdAt": "2023-01-13T11:39:47Z"
+      },
+      {
+        "id": 26846,
+        "recipientId": 35251,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/446/200/200",
+        "relationship": "가족",
+        "content": "한지민님의 메세지 내용 85",
+        "font": "Pretendard",
+        "createdAt": "2023-03-07T08:41:00Z"
+      },
+      {
+        "id": 91912,
+        "recipientId": 35251,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/70/200/200",
+        "relationship": "친구",
+        "content": "정우성님의 메세지 내용 94",
+        "font": "Pretendard",
+        "createdAt": "2023-07-06T10:59:43Z"
+      }
+    ],
+    "reactionCount": 96,
+    "topReactions": [
+      {
+        "id": 85370,
+        "emoji": "😀",
+        "count": 9
+      }
+    ]
+  },
+  {
+    "id": 16404,
+    "name": "정우성",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-02-23T07:55:55Z",
+    "messageCount": 9,
+    "recentMessages": [
+      {
+        "id": 89953,
+        "recipientId": 16404,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/4/200/200",
+        "relationship": "친구",
+        "content": "송혜교님의 메세지 내용 31",
+        "font": "Noto Sans",
+        "createdAt": "2023-11-18T03:28:41Z"
+      },
+      {
+        "id": 44698,
+        "recipientId": 16404,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/343/200/200",
+        "relationship": "가족",
+        "content": "현빈님의 메세지 내용 48",
+        "font": "Noto Sans",
+        "createdAt": "2023-12-03T23:14:10Z"
+      },
+      {
+        "id": 14294,
+        "recipientId": 16404,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/174/200/200",
+        "relationship": "친구",
+        "content": "전지현님의 메세지 내용 18",
+        "font": "Roboto",
+        "createdAt": "2023-11-22T08:04:12Z"
+      }
+    ],
+    "reactionCount": 76,
+    "topReactions": [
+      {
+        "id": 20609,
+        "emoji": "😀",
+        "count": 4
+      },
+      {
+        "id": 24638,
+        "emoji": "❤️",
+        "count": 8
+      },
+      {
+        "id": 38365,
+        "emoji": "👍",
+        "count": 20
+      },
+      {
+        "id": 16361,
+        "emoji": "😀",
+        "count": 2
+      },
+      {
+        "id": 41186,
+        "emoji": "👍",
+        "count": 20
+      }
+    ]
+  },
+  {
+    "id": 50859,
+    "name": "한지민",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/50859/600/400",
+    "createdAt": "2023-03-29T03:53:06Z",
+    "messageCount": 1,
+    "recentMessages": [
+      {
+        "id": 77856,
+        "recipientId": 50859,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/153/200/200",
+        "relationship": "가족",
+        "content": "정우성님의 메세지 내용 43",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-06-15T17:57:20Z"
+      }
+    ],
+    "reactionCount": 79,
+    "topReactions": [
+      {
+        "id": 36218,
+        "emoji": "😀",
+        "count": 9
+      }
+    ]
+  },
+  {
+    "id": 21841,
+    "name": "정우성",
+    "backgroundColor": "green",
+    "backgroundImageURL": null,
+    "createdAt": "2024-01-24T03:56:41Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 24360,
+        "recipientId": 21841,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/454/200/200",
+        "relationship": "가족",
+        "content": "송혜교님의 메세지 내용 45",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-05-23T11:32:35Z"
+      },
+      {
+        "id": 31827,
+        "recipientId": 21841,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/324/200/200",
+        "relationship": "친구",
+        "content": "박서준님의 메세지 내용 54",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-04-07T21:22:40Z"
+      },
+      {
+        "id": 42374,
+        "recipientId": 21841,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/296/200/200",
+        "relationship": "가족",
+        "content": "현빈님의 메세지 내용 42",
+        "font": "Roboto",
+        "createdAt": "2023-09-30T04:17:59Z"
+      }
+    ],
+    "reactionCount": 73,
+    "topReactions": [
+      {
+        "id": 24875,
+        "emoji": "😀",
+        "count": 12
+      },
+      {
+        "id": 99067,
+        "emoji": "❤️",
+        "count": 20
+      },
+      {
+        "id": 24734,
+        "emoji": "❤️",
+        "count": 20
+      },
+      {
+        "id": 3733,
+        "emoji": "👍",
+        "count": 10
+      },
+      {
+        "id": 54558,
+        "emoji": "🥹",
+        "count": 11
+      },
+      {
+        "id": 21392,
+        "emoji": "🎉",
+        "count": 18
+      }
+    ]
+  },
+  {
+    "id": 76780,
+    "name": "한지민",
+    "backgroundColor": "blue",
+    "backgroundImageURL": null,
+    "createdAt": "2023-03-09T13:34:00Z",
+    "messageCount": 2,
+    "recentMessages": [
+      {
+        "id": 51517,
+        "recipientId": 76780,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/379/200/200",
+        "relationship": "동료",
+        "content": "현빈님의 메세지 내용 45",
+        "font": "Pretendard",
+        "createdAt": "2023-02-16T02:02:14Z"
+      },
+      {
+        "id": 60139,
+        "recipientId": 76780,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/233/200/200",
+        "relationship": "동료",
+        "content": "박서준님의 메세지 내용 65",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-04-10T04:53:06Z"
+      }
+    ],
+    "reactionCount": 82,
+    "topReactions": [
+      {
+        "id": 53064,
+        "emoji": "❤️",
+        "count": 4
+      },
+      {
+        "id": 84662,
+        "emoji": "🎉",
+        "count": 16
+      },
+      {
+        "id": 15519,
+        "emoji": "❤️",
+        "count": 19
+      },
+      {
+        "id": 75306,
+        "emoji": "❤️",
+        "count": 19
+      },
+      {
+        "id": 59498,
+        "emoji": "😀",
+        "count": 14
+      }
+    ]
+  },
+  {
+    "id": 8022,
+    "name": "한지민",
+    "backgroundColor": "green",
+    "backgroundImageURL": null,
+    "createdAt": "2023-09-10T18:36:50Z",
+    "messageCount": 3,
+    "recentMessages": [
+      {
+        "id": 47963,
+        "recipientId": 8022,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/396/200/200",
+        "relationship": "가족",
+        "content": "이영준님의 메세지 내용 18",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-12-03T16:01:09Z"
+      },
+      {
+        "id": 2686,
+        "recipientId": 8022,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/310/200/200",
+        "relationship": "가족",
+        "content": "박서준님의 메세지 내용 24",
+        "font": "Roboto",
+        "createdAt": "2023-08-02T03:38:21Z"
+      },
+      {
+        "id": 64093,
+        "recipientId": 8022,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/126/200/200",
+        "relationship": "가족",
+        "content": "전지현님의 메세지 내용 16",
+        "font": "Roboto",
+        "createdAt": "2023-02-25T20:36:10Z"
+      }
+    ],
+    "reactionCount": 57,
+    "topReactions": [
+      {
+        "id": 67314,
+        "emoji": "🎉",
+        "count": 6
+      },
+      {
+        "id": 20708,
+        "emoji": "👍",
+        "count": 13
+      },
+      {
+        "id": 32217,
+        "emoji": "🥹",
+        "count": 8
+      },
+      {
+        "id": 59013,
+        "emoji": "😁",
+        "count": 9
+      }
+    ]
+  },
+  {
+    "id": 36777,
+    "name": "김하은",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/36777/600/400",
+    "createdAt": "2023-11-13T20:58:33Z",
+    "messageCount": 10,
+    "recentMessages": [
+      {
+        "id": 25834,
+        "recipientId": 36777,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/30/200/200",
+        "relationship": "가족",
+        "content": "최민수님의 메세지 내용 23",
+        "font": "Roboto",
+        "createdAt": "2023-09-22T02:37:47Z"
+      },
+      {
+        "id": 18411,
+        "recipientId": 36777,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/445/200/200",
+        "relationship": "가족",
+        "content": "정우성님의 메세지 내용 64",
+        "font": "Roboto",
+        "createdAt": "2023-09-24T01:46:01Z"
+      },
+      {
+        "id": 76753,
+        "recipientId": 36777,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/283/200/200",
+        "relationship": "동료",
+        "content": "김하은님의 메세지 내용 94",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-07-19T00:26:10Z"
+      }
+    ],
+    "reactionCount": 47,
+    "topReactions": [
+      {
+        "id": 81037,
+        "emoji": "🥹",
+        "count": 20
+      },
+      {
+        "id": 16358,
+        "emoji": "😁",
+        "count": 3
+      },
+      {
+        "id": 44167,
+        "emoji": "😀",
+        "count": 15
+      },
+      {
+        "id": 66141,
+        "emoji": "🎉",
+        "count": 19
+      }
+    ]
+  },
+  {
+    "id": 74659,
+    "name": "전지현",
+    "backgroundColor": "green",
+    "backgroundImageURL": null,
+    "createdAt": "2023-11-17T12:30:58Z",
+    "messageCount": 1,
+    "recentMessages": [
+      {
+        "id": 82067,
+        "recipientId": 74659,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/404/200/200",
+        "relationship": "지인",
+        "content": "박서준님의 메세지 내용 78",
+        "font": "Nanum Gothic",
+        "createdAt": "2024-01-18T12:11:24Z"
+      }
+    ],
+    "reactionCount": 43,
+    "topReactions": [
+      {
+        "id": 17924,
+        "emoji": "😀",
+        "count": 12
+      },
+      {
+        "id": 49600,
+        "emoji": "😀",
+        "count": 11
+      },
+      {
+        "id": 11142,
+        "emoji": "🥹",
+        "count": 7
+      }
+    ]
+  },
+  {
+    "id": 43809,
+    "name": "현빈",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/43809/600/400",
+    "createdAt": "2023-10-03T16:37:43Z",
+    "messageCount": 9,
+    "recentMessages": [
+      {
+        "id": 55697,
+        "recipientId": 43809,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/412/200/200",
+        "relationship": "친구",
+        "content": "송혜교님의 메세지 내용 3",
+        "font": "Roboto",
+        "createdAt": "2023-03-06T06:54:25Z"
+      },
+      {
+        "id": 41596,
+        "recipientId": 43809,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/439/200/200",
+        "relationship": "동료",
+        "content": "이병헌님의 메세지 내용 36",
+        "font": "Roboto",
+        "createdAt": "2023-02-12T07:13:07Z"
+      },
+      {
+        "id": 65835,
+        "recipientId": 43809,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/87/200/200",
+        "relationship": "친구",
+        "content": "정우성님의 메세지 내용 89",
+        "font": "Roboto",
+        "createdAt": "2023-06-21T12:20:45Z"
+      }
+    ],
+    "reactionCount": 45,
+    "topReactions": [
+      {
+        "id": 89452,
+        "emoji": "🥹",
+        "count": 11
+      },
+      {
+        "id": 83618,
+        "emoji": "😀",
+        "count": 12
+      }
+    ]
+  },
+  {
+    "id": 74443,
+    "name": "한지민",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2024-01-17T14:09:15Z",
+    "messageCount": 7,
+    "recentMessages": [
+      {
+        "id": 46450,
+        "recipientId": 74443,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/416/200/200",
+        "relationship": "가족",
+        "content": "현빈님의 메세지 내용 33",
+        "font": "Noto Sans",
+        "createdAt": "2024-02-01T01:10:37Z"
+      },
+      {
+        "id": 11534,
+        "recipientId": 74443,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/129/200/200",
+        "relationship": "친구",
+        "content": "김하은님의 메세지 내용 27",
+        "font": "Roboto",
+        "createdAt": "2024-02-04T19:36:42Z"
+      },
+      {
+        "id": 29956,
+        "recipientId": 74443,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/154/200/200",
+        "relationship": "지인",
+        "content": "이영준님의 메세지 내용 16",
+        "font": "Pretendard",
+        "createdAt": "2023-11-27T09:06:13Z"
+      }
+    ],
+    "reactionCount": 7,
+    "topReactions": [
+      {
+        "id": 45551,
+        "emoji": "❤️",
+        "count": 19
+      },
+      {
+        "id": 57044,
+        "emoji": "😁",
+        "count": 1
+      }
+    ]
+  },
+  {
+    "id": 62125,
+    "name": "현빈",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/62125/600/400",
+    "createdAt": "2023-11-29T07:54:55Z",
+    "messageCount": 9,
+    "recentMessages": [
+      {
+        "id": 48839,
+        "recipientId": 62125,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/498/200/200",
+        "relationship": "가족",
+        "content": "이영준님의 메세지 내용 22",
+        "font": "Pretendard",
+        "createdAt": "2023-10-25T11:05:34Z"
+      },
+      {
+        "id": 52003,
+        "recipientId": 62125,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/74/200/200",
+        "relationship": "가족",
+        "content": "전지현님의 메세지 내용 2",
+        "font": "Roboto",
+        "createdAt": "2023-11-20T16:46:22Z"
+      },
+      {
+        "id": 62162,
+        "recipientId": 62125,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/293/200/200",
+        "relationship": "지인",
+        "content": "이병헌님의 메세지 내용 93",
+        "font": "Roboto",
+        "createdAt": "2023-04-29T23:05:56Z"
+      }
+    ],
+    "reactionCount": 75,
+    "topReactions": [
+      {
+        "id": 11123,
+        "emoji": "🎉",
+        "count": 14
+      }
+    ]
+  },
+  {
+    "id": 32686,
+    "name": "정우성",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-09-25T19:47:20Z",
+    "messageCount": 7,
+    "recentMessages": [
+      {
+        "id": 25980,
+        "recipientId": 32686,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/361/200/200",
+        "relationship": "친구",
+        "content": "이영준님의 메세지 내용 13",
+        "font": "Noto Sans",
+        "createdAt": "2023-12-08T15:22:48Z"
+      },
+      {
+        "id": 73942,
+        "recipientId": 32686,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/397/200/200",
+        "relationship": "지인",
+        "content": "박서준님의 메세지 내용 6",
+        "font": "Noto Sans",
+        "createdAt": "2023-01-24T00:32:12Z"
+      },
+      {
+        "id": 85294,
+        "recipientId": 32686,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/46/200/200",
+        "relationship": "지인",
+        "content": "한지민님의 메세지 내용 38",
+        "font": "Noto Sans",
+        "createdAt": "2023-08-16T17:04:11Z"
+      }
+    ],
+    "reactionCount": 55,
+    "topReactions": [
+      {
+        "id": 79847,
+        "emoji": "👍",
+        "count": 9
+      },
+      {
+        "id": 33325,
+        "emoji": "🎉",
+        "count": 6
+      },
+      {
+        "id": 19452,
+        "emoji": "😀",
+        "count": 4
+      },
+      {
+        "id": 70794,
+        "emoji": "🥹",
+        "count": 20
+      },
+      {
+        "id": 55957,
+        "emoji": "😀",
+        "count": 20
+      },
+      {
+        "id": 1762,
+        "emoji": "🎉",
+        "count": 14
+      }
+    ]
+  },
+  {
+    "id": 58844,
+    "name": "최민수",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2023-12-01T03:42:08Z",
+    "messageCount": 10,
+    "recentMessages": [
+      {
+        "id": 49248,
+        "recipientId": 58844,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/171/200/200",
+        "relationship": "동료",
+        "content": "한지민님의 메세지 내용 11",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-03-24T16:30:51Z"
+      },
+      {
+        "id": 32838,
+        "recipientId": 58844,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/22/200/200",
+        "relationship": "지인",
+        "content": "김하은님의 메세지 내용 29",
+        "font": "Nanum Gothic",
+        "createdAt": "2024-01-03T03:12:01Z"
+      },
+      {
+        "id": 91516,
+        "recipientId": 58844,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/108/200/200",
+        "relationship": "가족",
+        "content": "이병헌님의 메세지 내용 82",
+        "font": "Pretendard",
+        "createdAt": "2023-08-27T12:05:46Z"
+      }
+    ],
+    "reactionCount": 20,
+    "topReactions": [
+      {
+        "id": 81634,
+        "emoji": "😀",
+        "count": 5
+      },
+      {
+        "id": 88135,
+        "emoji": "🥹",
+        "count": 16
+      },
+      {
+        "id": 86465,
+        "emoji": "😀",
+        "count": 13
+      },
+      {
+        "id": 92893,
+        "emoji": "❤️",
+        "count": 3
+      }
+    ]
+  },
+  {
+    "id": 72437,
+    "name": "현빈",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/72437/600/400",
+    "createdAt": "2023-08-28T14:40:53Z",
+    "messageCount": 2,
+    "recentMessages": [
+      {
+        "id": 73936,
+        "recipientId": 72437,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/317/200/200",
+        "relationship": "동료",
+        "content": "박서준님의 메세지 내용 18",
+        "font": "Noto Sans",
+        "createdAt": "2023-04-04T14:53:21Z"
+      },
+      {
+        "id": 29903,
+        "recipientId": 72437,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/106/200/200",
+        "relationship": "동료",
+        "content": "이병헌님의 메세지 내용 40",
+        "font": "Roboto",
+        "createdAt": "2023-04-29T16:49:48Z"
+      }
+    ],
+    "reactionCount": 98,
+    "topReactions": [
+      {
+        "id": 70510,
+        "emoji": "🎉",
+        "count": 20
+      },
+      {
+        "id": 66505,
+        "emoji": "👍",
+        "count": 3
+      },
+      {
+        "id": 66557,
+        "emoji": "❤️",
+        "count": 12
+      },
+      {
+        "id": 61631,
+        "emoji": "😁",
+        "count": 20
+      }
+    ]
+  },
+  {
+    "id": 31124,
+    "name": "한지민",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-09-22T15:01:23Z",
+    "messageCount": 7,
+    "recentMessages": [
+      {
+        "id": 24005,
+        "recipientId": 31124,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/440/200/200",
+        "relationship": "친구",
+        "content": "이영준님의 메세지 내용 80",
+        "font": "Roboto",
+        "createdAt": "2023-12-17T16:17:25Z"
+      },
+      {
+        "id": 68955,
+        "recipientId": 31124,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/6/200/200",
+        "relationship": "지인",
+        "content": "김하은님의 메세지 내용 85",
+        "font": "Roboto",
+        "createdAt": "2023-07-18T06:13:13Z"
+      },
+      {
+        "id": 91691,
+        "recipientId": 31124,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/461/200/200",
+        "relationship": "지인",
+        "content": "이병헌님의 메세지 내용 53",
+        "font": "Roboto",
+        "createdAt": "2023-05-21T09:55:42Z"
+      }
+    ],
+    "reactionCount": 91,
+    "topReactions": [
+      {
+        "id": 70597,
+        "emoji": "😁",
+        "count": 10
+      },
+      {
+        "id": 86461,
+        "emoji": "👍",
+        "count": 11
+      }
+    ]
+  },
+  {
+    "id": 73111,
+    "name": "이병헌",
+    "backgroundColor": "blue",
+    "backgroundImageURL": null,
+    "createdAt": "2023-12-29T11:24:51Z",
+    "messageCount": 2,
+    "recentMessages": [
+      {
+        "id": 19737,
+        "recipientId": 73111,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/434/200/200",
+        "relationship": "동료",
+        "content": "이영준님의 메세지 내용 87",
+        "font": "Noto Sans",
+        "createdAt": "2023-02-10T04:25:44Z"
+      },
+      {
+        "id": 24750,
+        "recipientId": 73111,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/52/200/200",
+        "relationship": "가족",
+        "content": "이영준님의 메세지 내용 49",
+        "font": "Roboto",
+        "createdAt": "2023-10-10T22:47:57Z"
+      }
+    ],
+    "reactionCount": 16,
+    "topReactions": [
+      {
+        "id": 42626,
+        "emoji": "😀",
+        "count": 7
+      },
+      {
+        "id": 2933,
+        "emoji": "😁",
+        "count": 19
+      },
+      {
+        "id": 8592,
+        "emoji": "👍",
+        "count": 20
+      },
+      {
+        "id": 33974,
+        "emoji": "😀",
+        "count": 9
+      }
+    ]
+  },
+  {
+    "id": 44599,
+    "name": "최민수",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-12-01T19:25:38Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 77427,
+        "recipientId": 44599,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/9/200/200",
+        "relationship": "지인",
+        "content": "전지현님의 메세지 내용 7",
+        "font": "Noto Sans",
+        "createdAt": "2024-01-08T12:37:16Z"
+      },
+      {
+        "id": 2974,
+        "recipientId": 44599,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/46/200/200",
+        "relationship": "친구",
+        "content": "이병헌님의 메세지 내용 13",
+        "font": "Roboto",
+        "createdAt": "2023-11-11T07:56:34Z"
+      },
+      {
+        "id": 31985,
+        "recipientId": 44599,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/340/200/200",
+        "relationship": "지인",
+        "content": "정우성님의 메세지 내용 27",
+        "font": "Pretendard",
+        "createdAt": "2023-12-03T01:18:34Z"
+      }
+    ],
+    "reactionCount": 54,
+    "topReactions": [
+      {
+        "id": 69943,
+        "emoji": "🥹",
+        "count": 8
+      },
+      {
+        "id": 93387,
+        "emoji": "😀",
+        "count": 10
+      },
+      {
+        "id": 55895,
+        "emoji": "❤️",
+        "count": 12
+      },
+      {
+        "id": 1552,
+        "emoji": "🥹",
+        "count": 13
+      },
+      {
+        "id": 62897,
+        "emoji": "❤️",
+        "count": 8
+      },
+      {
+        "id": 11953,
+        "emoji": "👍",
+        "count": 9
+      }
+    ]
+  },
+  {
+    "id": 53998,
+    "name": "최민수",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/53998/600/400",
+    "createdAt": "2023-05-21T05:46:16Z",
+    "messageCount": 9,
+    "recentMessages": [
+      {
+        "id": 42481,
+        "recipientId": 53998,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/226/200/200",
+        "relationship": "동료",
+        "content": "정우성님의 메세지 내용 83",
+        "font": "Pretendard",
+        "createdAt": "2023-12-02T23:46:08Z"
+      },
+      {
+        "id": 45560,
+        "recipientId": 53998,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/336/200/200",
+        "relationship": "가족",
+        "content": "전지현님의 메세지 내용 93",
+        "font": "Pretendard",
+        "createdAt": "2023-04-05T16:17:22Z"
+      },
+      {
+        "id": 44511,
+        "recipientId": 53998,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/401/200/200",
+        "relationship": "가족",
+        "content": "이영준님의 메세지 내용 24",
+        "font": "Noto Sans",
+        "createdAt": "2023-12-30T08:26:11Z"
+      }
+    ],
+    "reactionCount": 99,
+    "topReactions": [
+      {
+        "id": 26899,
+        "emoji": "🥹",
+        "count": 19
+      },
+      {
+        "id": 64192,
+        "emoji": "😀",
+        "count": 20
+      },
+      {
+        "id": 38049,
+        "emoji": "🥹",
+        "count": 12
+      },
+      {
+        "id": 3255,
+        "emoji": "❤️",
+        "count": 3
+      },
+      {
+        "id": 35106,
+        "emoji": "👍",
+        "count": 17
+      }
+    ]
+  },
+  {
+    "id": 89555,
+    "name": "정우성",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/89555/600/400",
+    "createdAt": "2023-11-04T11:24:31Z",
+    "messageCount": 10,
+    "recentMessages": [
+      {
+        "id": 75585,
+        "recipientId": 89555,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/82/200/200",
+        "relationship": "가족",
+        "content": "현빈님의 메세지 내용 79",
+        "font": "Noto Sans",
+        "createdAt": "2023-08-27T02:20:45Z"
+      },
+      {
+        "id": 45846,
+        "recipientId": 89555,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/66/200/200",
+        "relationship": "친구",
+        "content": "정우성님의 메세지 내용 16",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-12-16T12:24:17Z"
+      },
+      {
+        "id": 78446,
+        "recipientId": 89555,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/162/200/200",
+        "relationship": "가족",
+        "content": "김하은님의 메세지 내용 43",
+        "font": "Roboto",
+        "createdAt": "2023-10-20T14:00:34Z"
+      }
+    ],
+    "reactionCount": 81,
+    "topReactions": [
+      {
+        "id": 40481,
+        "emoji": "😁",
+        "count": 6
+      },
+      {
+        "id": 89819,
+        "emoji": "👍",
+        "count": 5
+      },
+      {
+        "id": 56551,
+        "emoji": "🎉",
+        "count": 8
+      },
+      {
+        "id": 90383,
+        "emoji": "🎉",
+        "count": 8
+      },
+      {
+        "id": 48052,
+        "emoji": "😁",
+        "count": 4
+      },
+      {
+        "id": 53141,
+        "emoji": "🎉",
+        "count": 10
+      }
+    ]
+  },
+  {
+    "id": 12891,
+    "name": "전지현",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/12891/600/400",
+    "createdAt": "2023-04-02T10:50:44Z",
+    "messageCount": 6,
+    "recentMessages": [
+      {
+        "id": 69504,
+        "recipientId": 12891,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/372/200/200",
+        "relationship": "지인",
+        "content": "김하은님의 메세지 내용 100",
+        "font": "Noto Sans",
+        "createdAt": "2023-06-24T18:34:35Z"
+      },
+      {
+        "id": 16122,
+        "recipientId": 12891,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/384/200/200",
+        "relationship": "지인",
+        "content": "송혜교님의 메세지 내용 61",
+        "font": "Pretendard",
+        "createdAt": "2024-01-15T10:37:45Z"
+      },
+      {
+        "id": 48360,
+        "recipientId": 12891,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/331/200/200",
+        "relationship": "가족",
+        "content": "송혜교님의 메세지 내용 9",
+        "font": "Noto Sans",
+        "createdAt": "2024-01-22T14:41:55Z"
+      }
+    ],
+    "reactionCount": 91,
+    "topReactions": [
+      {
+        "id": 22984,
+        "emoji": "😁",
+        "count": 2
+      },
+      {
+        "id": 38976,
+        "emoji": "😀",
+        "count": 1
+      }
+    ]
+  },
+  {
+    "id": 21026,
+    "name": "현빈",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/21026/600/400",
+    "createdAt": "2023-06-24T21:14:04Z",
+    "messageCount": 2,
+    "recentMessages": [
+      {
+        "id": 78110,
+        "recipientId": 21026,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/86/200/200",
+        "relationship": "동료",
+        "content": "정우성님의 메세지 내용 72",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-10-03T05:53:18Z"
+      },
+      {
+        "id": 17655,
+        "recipientId": 21026,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/24/200/200",
+        "relationship": "지인",
+        "content": "김하은님의 메세지 내용 99",
+        "font": "Noto Sans",
+        "createdAt": "2023-02-16T19:23:42Z"
+      }
+    ],
+    "reactionCount": 48,
+    "topReactions": [
+      {
+        "id": 64931,
+        "emoji": "❤️",
+        "count": 5
+      },
+      {
+        "id": 32976,
+        "emoji": "🎉",
+        "count": 19
+      }
+    ]
+  },
+  {
+    "id": 72332,
+    "name": "이병헌",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/72332/600/400",
+    "createdAt": "2023-10-08T20:12:12Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 88347,
+        "recipientId": 72332,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/25/200/200",
+        "relationship": "친구",
+        "content": "정우성님의 메세지 내용 18",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-07-12T05:02:22Z"
+      },
+      {
+        "id": 18515,
+        "recipientId": 72332,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/259/200/200",
+        "relationship": "친구",
+        "content": "현빈님의 메세지 내용 35",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-02-04T02:14:10Z"
+      },
+      {
+        "id": 10191,
+        "recipientId": 72332,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/400/200/200",
+        "relationship": "지인",
+        "content": "전지현님의 메세지 내용 76",
+        "font": "Pretendard",
+        "createdAt": "2023-07-03T21:04:14Z"
+      }
+    ],
+    "reactionCount": 84,
+    "topReactions": [
+      {
+        "id": 34056,
+        "emoji": "🎉",
+        "count": 9
+      }
+    ]
+  },
+  {
+    "id": 9856,
+    "name": "이영준",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-04-25T13:16:15Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 62780,
+        "recipientId": 9856,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/466/200/200",
+        "relationship": "친구",
+        "content": "최민수님의 메세지 내용 28",
+        "font": "Nanum Gothic",
+        "createdAt": "2024-01-09T20:20:07Z"
+      },
+      {
+        "id": 87691,
+        "recipientId": 9856,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/219/200/200",
+        "relationship": "동료",
+        "content": "전지현님의 메세지 내용 11",
+        "font": "Pretendard",
+        "createdAt": "2023-09-13T03:47:51Z"
+      },
+      {
+        "id": 33613,
+        "recipientId": 9856,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/231/200/200",
+        "relationship": "가족",
+        "content": "박서준님의 메세지 내용 14",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-05-13T08:02:20Z"
+      }
+    ],
+    "reactionCount": 86,
+    "topReactions": [
+      {
+        "id": 11941,
+        "emoji": "😀",
+        "count": 10
+      }
+    ]
+  },
+  {
+    "id": 6048,
+    "name": "한지민",
+    "backgroundColor": "green",
+    "backgroundImageURL": null,
+    "createdAt": "2023-11-21T11:02:16Z",
+    "messageCount": 5,
+    "recentMessages": [
+      {
+        "id": 47612,
+        "recipientId": 6048,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/97/200/200",
+        "relationship": "친구",
+        "content": "이병헌님의 메세지 내용 72",
+        "font": "Pretendard",
+        "createdAt": "2023-12-11T12:42:57Z"
+      },
+      {
+        "id": 50485,
+        "recipientId": 6048,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/84/200/200",
+        "relationship": "친구",
+        "content": "최민수님의 메세지 내용 24",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-12-01T20:34:55Z"
+      },
+      {
+        "id": 42372,
+        "recipientId": 6048,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/478/200/200",
+        "relationship": "지인",
+        "content": "최민수님의 메세지 내용 38",
+        "font": "Roboto",
+        "createdAt": "2023-09-10T14:19:59Z"
+      }
+    ],
+    "reactionCount": 93,
+    "topReactions": [
+      {
+        "id": 85562,
+        "emoji": "👍",
+        "count": 14
+      },
+      {
+        "id": 19775,
+        "emoji": "❤️",
+        "count": 4
+      },
+      {
+        "id": 97219,
+        "emoji": "❤️",
+        "count": 18
+      },
+      {
+        "id": 77812,
+        "emoji": "🎉",
+        "count": 3
+      }
+    ]
+  },
+  {
+    "id": 7768,
+    "name": "송혜교",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/7768/600/400",
+    "createdAt": "2024-02-03T06:34:20Z",
+    "messageCount": 3,
+    "recentMessages": [
+      {
+        "id": 91935,
+        "recipientId": 7768,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/196/200/200",
+        "relationship": "가족",
+        "content": "이영준님의 메세지 내용 39",
+        "font": "Noto Sans",
+        "createdAt": "2023-10-26T02:05:13Z"
+      },
+      {
+        "id": 54283,
+        "recipientId": 7768,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/368/200/200",
+        "relationship": "가족",
+        "content": "이병헌님의 메세지 내용 8",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-02-19T15:25:55Z"
+      },
+      {
+        "id": 22996,
+        "recipientId": 7768,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/323/200/200",
+        "relationship": "동료",
+        "content": "박서준님의 메세지 내용 36",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-05-07T10:13:46Z"
+      }
+    ],
+    "reactionCount": 17,
+    "topReactions": [
+      {
+        "id": 56016,
+        "emoji": "😁",
+        "count": 7
+      }
+    ]
+  },
+  {
+    "id": 60032,
+    "name": "정우성",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/60032/600/400",
+    "createdAt": "2023-05-02T10:55:07Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 16669,
+        "recipientId": 60032,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/209/200/200",
+        "relationship": "친구",
+        "content": "이영준님의 메세지 내용 97",
+        "font": "Roboto",
+        "createdAt": "2023-10-20T20:11:37Z"
+      },
+      {
+        "id": 91971,
+        "recipientId": 60032,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/494/200/200",
+        "relationship": "친구",
+        "content": "한지민님의 메세지 내용 6",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-09-08T08:31:38Z"
+      },
+      {
+        "id": 66344,
+        "recipientId": 60032,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/444/200/200",
+        "relationship": "친구",
+        "content": "이병헌님의 메세지 내용 47",
+        "font": "Pretendard",
+        "createdAt": "2023-07-26T07:54:55Z"
+      }
+    ],
+    "reactionCount": 61,
+    "topReactions": [
+      {
+        "id": 79749,
+        "emoji": "😀",
+        "count": 11
+      }
+    ]
+  },
+  {
+    "id": 90521,
+    "name": "김하은",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/90521/600/400",
+    "createdAt": "2023-04-23T15:43:22Z",
+    "messageCount": 1,
+    "recentMessages": [
+      {
+        "id": 84413,
+        "recipientId": 90521,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/266/200/200",
+        "relationship": "가족",
+        "content": "박서준님의 메세지 내용 66",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-10-18T10:21:59Z"
+      }
+    ],
+    "reactionCount": 58,
+    "topReactions": [
+      {
+        "id": 15557,
+        "emoji": "❤️",
+        "count": 1
+      },
+      {
+        "id": 87847,
+        "emoji": "❤️",
+        "count": 5
+      }
+    ]
+  },
+  {
+    "id": 88686,
+    "name": "김하은",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/88686/600/400",
+    "createdAt": "2023-10-03T13:17:00Z",
+    "messageCount": 1,
+    "recentMessages": [
+      {
+        "id": 94186,
+        "recipientId": 88686,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/271/200/200",
+        "relationship": "지인",
+        "content": "이영준님의 메세지 내용 5",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-09-06T14:11:21Z"
+      }
+    ],
+    "reactionCount": 83,
+    "topReactions": [
+      {
+        "id": 19026,
+        "emoji": "🎉",
+        "count": 9
+      },
+      {
+        "id": 66458,
+        "emoji": "🥹",
+        "count": 18
+      },
+      {
+        "id": 39586,
+        "emoji": "❤️",
+        "count": 7
+      },
+      {
+        "id": 19251,
+        "emoji": "🥹",
+        "count": 17
+      },
+      {
+        "id": 4095,
+        "emoji": "🥹",
+        "count": 13
+      }
+    ]
+  },
+  {
+    "id": 19057,
+    "name": "현빈",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/19057/600/400",
+    "createdAt": "2023-08-11T17:15:28Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 77529,
+        "recipientId": 19057,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/20/200/200",
+        "relationship": "가족",
+        "content": "최민수님의 메세지 내용 29",
+        "font": "Pretendard",
+        "createdAt": "2024-01-29T23:03:48Z"
+      },
+      {
+        "id": 90459,
+        "recipientId": 19057,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/264/200/200",
+        "relationship": "친구",
+        "content": "김하은님의 메세지 내용 15",
+        "font": "Roboto",
+        "createdAt": "2023-08-14T06:22:29Z"
+      },
+      {
+        "id": 34301,
+        "recipientId": 19057,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/172/200/200",
+        "relationship": "친구",
+        "content": "김하은님의 메세지 내용 66",
+        "font": "Noto Sans",
+        "createdAt": "2024-01-21T14:02:39Z"
+      }
+    ],
+    "reactionCount": 47,
+    "topReactions": [
+      {
+        "id": 55806,
+        "emoji": "😀",
+        "count": 9
+      },
+      {
+        "id": 81344,
+        "emoji": "🎉",
+        "count": 20
+      },
+      {
+        "id": 23760,
+        "emoji": "😁",
+        "count": 7
+      },
+      {
+        "id": 95115,
+        "emoji": "❤️",
+        "count": 10
+      },
+      {
+        "id": 62637,
+        "emoji": "😀",
+        "count": 2
+      }
+    ]
+  },
+  {
+    "id": 27685,
+    "name": "김하은",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2023-12-05T11:32:51Z",
+    "messageCount": 6,
+    "recentMessages": [
+      {
+        "id": 47201,
+        "recipientId": 27685,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/309/200/200",
+        "relationship": "동료",
+        "content": "최민수님의 메세지 내용 20",
+        "font": "Pretendard",
+        "createdAt": "2023-09-27T00:49:21Z"
+      },
+      {
+        "id": 62272,
+        "recipientId": 27685,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/63/200/200",
+        "relationship": "동료",
+        "content": "한지민님의 메세지 내용 7",
+        "font": "Roboto",
+        "createdAt": "2023-01-26T03:30:29Z"
+      },
+      {
+        "id": 20963,
+        "recipientId": 27685,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/385/200/200",
+        "relationship": "친구",
+        "content": "김하은님의 메세지 내용 44",
+        "font": "Pretendard",
+        "createdAt": "2023-11-26T17:32:56Z"
+      }
+    ],
+    "reactionCount": 15,
+    "topReactions": [
+      {
+        "id": 12348,
+        "emoji": "🎉",
+        "count": 8
+      },
+      {
+        "id": 54843,
+        "emoji": "👍",
+        "count": 15
+      },
+      {
+        "id": 79979,
+        "emoji": "👍",
+        "count": 1
+      },
+      {
+        "id": 20768,
+        "emoji": "👍",
+        "count": 20
+      },
+      {
+        "id": 16109,
+        "emoji": "❤️",
+        "count": 1
+      },
+      {
+        "id": 10264,
+        "emoji": "😁",
+        "count": 9
+      }
+    ]
+  },
+  {
+    "id": 27107,
+    "name": "이영준",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/27107/600/400",
+    "createdAt": "2023-12-02T07:20:10Z",
+    "messageCount": 1,
+    "recentMessages": [
+      {
+        "id": 97932,
+        "recipientId": 27107,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/497/200/200",
+        "relationship": "가족",
+        "content": "최민수님의 메세지 내용 78",
+        "font": "Roboto",
+        "createdAt": "2023-09-11T04:54:00Z"
+      }
+    ],
+    "reactionCount": 55,
+    "topReactions": [
+      {
+        "id": 65130,
+        "emoji": "👍",
+        "count": 7
+      },
+      {
+        "id": 3875,
+        "emoji": "😁",
+        "count": 15
+      },
+      {
+        "id": 93476,
+        "emoji": "❤️",
+        "count": 16
+      },
+      {
+        "id": 22262,
+        "emoji": "🥹",
+        "count": 2
+      }
+    ]
+  },
+  {
+    "id": 5946,
+    "name": "이영준",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/5946/600/400",
+    "createdAt": "2024-01-08T03:36:35Z",
+    "messageCount": 2,
+    "recentMessages": [
+      {
+        "id": 66117,
+        "recipientId": 5946,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/453/200/200",
+        "relationship": "지인",
+        "content": "최민수님의 메세지 내용 70",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-10-08T04:49:43Z"
+      },
+      {
+        "id": 33590,
+        "recipientId": 5946,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/446/200/200",
+        "relationship": "지인",
+        "content": "정우성님의 메세지 내용 45",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-02-24T20:46:51Z"
+      }
+    ],
+    "reactionCount": 80,
+    "topReactions": [
+      {
+        "id": 90187,
+        "emoji": "😀",
+        "count": 6
+      },
+      {
+        "id": 26989,
+        "emoji": "🥹",
+        "count": 8
+      },
+      {
+        "id": 80780,
+        "emoji": "🥹",
+        "count": 15
+      },
+      {
+        "id": 4359,
+        "emoji": "🎉",
+        "count": 15
+      },
+      {
+        "id": 25620,
+        "emoji": "👍",
+        "count": 10
+      }
+    ]
+  },
+  {
+    "id": 28566,
+    "name": "정우성",
+    "backgroundColor": "blue",
+    "backgroundImageURL": null,
+    "createdAt": "2023-11-09T11:10:28Z",
+    "messageCount": 1,
+    "recentMessages": [
+      {
+        "id": 19714,
+        "recipientId": 28566,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/177/200/200",
+        "relationship": "친구",
+        "content": "한지민님의 메세지 내용 25",
+        "font": "Pretendard",
+        "createdAt": "2023-07-21T02:56:53Z"
+      }
+    ],
+    "reactionCount": 4,
+    "topReactions": [
+      {
+        "id": 71201,
+        "emoji": "😀",
+        "count": 5
+      },
+      {
+        "id": 4897,
+        "emoji": "🥹",
+        "count": 4
+      },
+      {
+        "id": 64978,
+        "emoji": "😁",
+        "count": 12
+      },
+      {
+        "id": 69162,
+        "emoji": "🥹",
+        "count": 1
+      },
+      {
+        "id": 99414,
+        "emoji": "😀",
+        "count": 5
+      },
+      {
+        "id": 2807,
+        "emoji": "🥹",
+        "count": 7
+      }
+    ]
+  },
+  {
+    "id": 84533,
+    "name": "김하은",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2024-01-08T03:10:08Z",
+    "messageCount": 9,
+    "recentMessages": [
+      {
+        "id": 25694,
+        "recipientId": 84533,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/96/200/200",
+        "relationship": "친구",
+        "content": "한지민님의 메세지 내용 36",
+        "font": "Pretendard",
+        "createdAt": "2023-01-14T06:23:45Z"
+      },
+      {
+        "id": 89853,
+        "recipientId": 84533,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/52/200/200",
+        "relationship": "친구",
+        "content": "정우성님의 메세지 내용 28",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-06-23T08:29:50Z"
+      },
+      {
+        "id": 3101,
+        "recipientId": 84533,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/28/200/200",
+        "relationship": "가족",
+        "content": "현빈님의 메세지 내용 63",
+        "font": "Nanum Gothic",
+        "createdAt": "2024-01-12T05:42:09Z"
+      }
+    ],
+    "reactionCount": 23,
+    "topReactions": [
+      {
+        "id": 7041,
+        "emoji": "😁",
+        "count": 6
+      },
+      {
+        "id": 19313,
+        "emoji": "😀",
+        "count": 1
+      },
+      {
+        "id": 22714,
+        "emoji": "👍",
+        "count": 12
+      },
+      {
+        "id": 12076,
+        "emoji": "👍",
+        "count": 18
+      },
+      {
+        "id": 8583,
+        "emoji": "🎉",
+        "count": 5
+      }
+    ]
+  },
+  {
+    "id": 96506,
+    "name": "박서준",
+    "backgroundColor": "blue",
+    "backgroundImageURL": null,
+    "createdAt": "2023-06-09T15:04:25Z",
+    "messageCount": 6,
+    "recentMessages": [
+      {
+        "id": 48175,
+        "recipientId": 96506,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/145/200/200",
+        "relationship": "동료",
+        "content": "이병헌님의 메세지 내용 86",
+        "font": "Pretendard",
+        "createdAt": "2023-03-13T10:17:35Z"
+      },
+      {
+        "id": 93664,
+        "recipientId": 96506,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/238/200/200",
+        "relationship": "친구",
+        "content": "전지현님의 메세지 내용 22",
+        "font": "Noto Sans",
+        "createdAt": "2023-12-31T04:01:30Z"
+      },
+      {
+        "id": 17811,
+        "recipientId": 96506,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/87/200/200",
+        "relationship": "친구",
+        "content": "최민수님의 메세지 내용 26",
+        "font": "Noto Sans",
+        "createdAt": "2024-01-16T04:31:27Z"
+      }
+    ],
+    "reactionCount": 29,
+    "topReactions": [
+      {
+        "id": 52114,
+        "emoji": "🥹",
+        "count": 8
+      },
+      {
+        "id": 93670,
+        "emoji": "🥹",
+        "count": 18
+      },
+      {
+        "id": 34535,
+        "emoji": "🎉",
+        "count": 1
+      },
+      {
+        "id": 34032,
+        "emoji": "🥹",
+        "count": 3
+      },
+      {
+        "id": 24268,
+        "emoji": "😁",
+        "count": 2
+      }
+    ]
+  },
+  {
+    "id": 83453,
+    "name": "김하은",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-08-02T05:41:33Z",
+    "messageCount": 10,
+    "recentMessages": [
+      {
+        "id": 62207,
+        "recipientId": 83453,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/181/200/200",
+        "relationship": "동료",
+        "content": "전지현님의 메세지 내용 88",
+        "font": "Roboto",
+        "createdAt": "2023-12-18T17:43:56Z"
+      },
+      {
+        "id": 64882,
+        "recipientId": 83453,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/145/200/200",
+        "relationship": "친구",
+        "content": "이영준님의 메세지 내용 95",
+        "font": "Roboto",
+        "createdAt": "2023-10-19T03:30:01Z"
+      },
+      {
+        "id": 51419,
+        "recipientId": 83453,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/161/200/200",
+        "relationship": "가족",
+        "content": "현빈님의 메세지 내용 98",
+        "font": "Roboto",
+        "createdAt": "2023-02-09T11:45:22Z"
+      }
+    ],
+    "reactionCount": 10,
+    "topReactions": [
+      {
+        "id": 34005,
+        "emoji": "🎉",
+        "count": 7
+      }
+    ]
+  },
+  {
+    "id": 74991,
+    "name": "한지민",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/74991/600/400",
+    "createdAt": "2023-03-21T17:29:11Z",
+    "messageCount": 10,
+    "recentMessages": [
+      {
+        "id": 43900,
+        "recipientId": 74991,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/306/200/200",
+        "relationship": "지인",
+        "content": "정우성님의 메세지 내용 74",
+        "font": "Roboto",
+        "createdAt": "2024-01-11T12:45:15Z"
+      },
+      {
+        "id": 23958,
+        "recipientId": 74991,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/14/200/200",
+        "relationship": "가족",
+        "content": "전지현님의 메세지 내용 84",
+        "font": "Pretendard",
+        "createdAt": "2023-05-03T21:07:40Z"
+      },
+      {
+        "id": 89183,
+        "recipientId": 74991,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/355/200/200",
+        "relationship": "친구",
+        "content": "김하은님의 메세지 내용 91",
+        "font": "Pretendard",
+        "createdAt": "2023-04-27T03:48:45Z"
+      }
+    ],
+    "reactionCount": 45,
+    "topReactions": [
+      {
+        "id": 30409,
+        "emoji": "🎉",
+        "count": 9
+      },
+      {
+        "id": 96020,
+        "emoji": "👍",
+        "count": 19
+      }
+    ]
+  },
+  {
+    "id": 10732,
+    "name": "현빈",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2024-01-29T01:17:08Z",
+    "messageCount": 10,
+    "recentMessages": [
+      {
+        "id": 28091,
+        "recipientId": 10732,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/214/200/200",
+        "relationship": "친구",
+        "content": "송혜교님의 메세지 내용 90",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-02-16T06:24:10Z"
+      },
+      {
+        "id": 96968,
+        "recipientId": 10732,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/334/200/200",
+        "relationship": "가족",
+        "content": "이영준님의 메세지 내용 86",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-04-29T02:44:44Z"
+      },
+      {
+        "id": 11805,
+        "recipientId": 10732,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/76/200/200",
+        "relationship": "지인",
+        "content": "이병헌님의 메세지 내용 48",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-12-29T05:06:21Z"
+      }
+    ],
+    "reactionCount": 45,
+    "topReactions": [
+      {
+        "id": 75995,
+        "emoji": "🎉",
+        "count": 14
+      },
+      {
+        "id": 83468,
+        "emoji": "👍",
+        "count": 6
+      },
+      {
+        "id": 3826,
+        "emoji": "🎉",
+        "count": 6
+      },
+      {
+        "id": 53081,
+        "emoji": "❤️",
+        "count": 14
+      }
+    ]
+  },
+  {
+    "id": 46305,
+    "name": "현빈",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/46305/600/400",
+    "createdAt": "2023-02-20T22:15:25Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 94045,
+        "recipientId": 46305,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/2/200/200",
+        "relationship": "지인",
+        "content": "현빈님의 메세지 내용 65",
+        "font": "Noto Sans",
+        "createdAt": "2023-02-05T06:10:36Z"
+      },
+      {
+        "id": 27482,
+        "recipientId": 46305,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/443/200/200",
+        "relationship": "친구",
+        "content": "정우성님의 메세지 내용 4",
+        "font": "Noto Sans",
+        "createdAt": "2023-02-22T15:24:55Z"
+      },
+      {
+        "id": 33966,
+        "recipientId": 46305,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/394/200/200",
+        "relationship": "가족",
+        "content": "이영준님의 메세지 내용 33",
+        "font": "Noto Sans",
+        "createdAt": "2023-05-08T01:31:25Z"
+      }
+    ],
+    "reactionCount": 99,
+    "topReactions": [
+      {
+        "id": 22251,
+        "emoji": "👍",
+        "count": 13
+      }
+    ]
+  },
+  {
+    "id": 64061,
+    "name": "현빈",
+    "backgroundColor": "green",
+    "backgroundImageURL": null,
+    "createdAt": "2023-05-08T17:59:24Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 23840,
+        "recipientId": 64061,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/74/200/200",
+        "relationship": "지인",
+        "content": "이영준님의 메세지 내용 74",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-07-23T08:30:41Z"
+      },
+      {
+        "id": 94450,
+        "recipientId": 64061,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/353/200/200",
+        "relationship": "친구",
+        "content": "이병헌님의 메세지 내용 61",
+        "font": "Pretendard",
+        "createdAt": "2023-12-02T06:48:01Z"
+      },
+      {
+        "id": 14478,
+        "recipientId": 64061,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/435/200/200",
+        "relationship": "지인",
+        "content": "송혜교님의 메세지 내용 13",
+        "font": "Roboto",
+        "createdAt": "2023-02-11T15:00:07Z"
+      }
+    ],
+    "reactionCount": 9,
+    "topReactions": [
+      {
+        "id": 16899,
+        "emoji": "🥹",
+        "count": 5
+      }
+    ]
+  },
+  {
+    "id": 15549,
+    "name": "이병헌",
+    "backgroundColor": "blue",
+    "backgroundImageURL": null,
+    "createdAt": "2023-12-13T10:07:11Z",
+    "messageCount": 7,
+    "recentMessages": [
+      {
+        "id": 25725,
+        "recipientId": 15549,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/22/200/200",
+        "relationship": "가족",
+        "content": "최민수님의 메세지 내용 37",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-06-08T04:48:57Z"
+      },
+      {
+        "id": 60095,
+        "recipientId": 15549,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/425/200/200",
+        "relationship": "동료",
+        "content": "정우성님의 메세지 내용 83",
+        "font": "Noto Sans",
+        "createdAt": "2023-01-05T05:19:05Z"
+      },
+      {
+        "id": 24093,
+        "recipientId": 15549,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/328/200/200",
+        "relationship": "동료",
+        "content": "현빈님의 메세지 내용 66",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-06-17T11:09:48Z"
+      }
+    ],
+    "reactionCount": 72,
+    "topReactions": [
+      {
+        "id": 71384,
+        "emoji": "👍",
+        "count": 8
+      },
+      {
+        "id": 23202,
+        "emoji": "👍",
+        "count": 19
+      },
+      {
+        "id": 98227,
+        "emoji": "👍",
+        "count": 15
+      },
+      {
+        "id": 17552,
+        "emoji": "🥹",
+        "count": 14
+      }
+    ]
+  },
+  {
+    "id": 84213,
+    "name": "송혜교",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/84213/600/400",
+    "createdAt": "2023-12-21T22:50:35Z",
+    "messageCount": 10,
+    "recentMessages": [
+      {
+        "id": 76650,
+        "recipientId": 84213,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/401/200/200",
+        "relationship": "동료",
+        "content": "최민수님의 메세지 내용 23",
+        "font": "Roboto",
+        "createdAt": "2023-11-24T00:40:50Z"
+      },
+      {
+        "id": 67124,
+        "recipientId": 84213,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/482/200/200",
+        "relationship": "가족",
+        "content": "이병헌님의 메세지 내용 81",
+        "font": "Pretendard",
+        "createdAt": "2023-04-16T14:42:59Z"
+      },
+      {
+        "id": 92607,
+        "recipientId": 84213,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/428/200/200",
+        "relationship": "가족",
+        "content": "송혜교님의 메세지 내용 89",
+        "font": "Roboto",
+        "createdAt": "2023-02-24T01:40:42Z"
+      }
+    ],
+    "reactionCount": 5,
+    "topReactions": [
+      {
+        "id": 84810,
+        "emoji": "😀",
+        "count": 13
+      },
+      {
+        "id": 42243,
+        "emoji": "🥹",
+        "count": 6
+      },
+      {
+        "id": 63560,
+        "emoji": "👍",
+        "count": 10
+      },
+      {
+        "id": 6972,
+        "emoji": "🥹",
+        "count": 4
+      },
+      {
+        "id": 32485,
+        "emoji": "😁",
+        "count": 1
+      },
+      {
+        "id": 29060,
+        "emoji": "😁",
+        "count": 10
+      }
+    ]
+  },
+  {
+    "id": 90495,
+    "name": "최민수",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/90495/600/400",
+    "createdAt": "2023-04-23T14:47:14Z",
+    "messageCount": 7,
+    "recentMessages": [
+      {
+        "id": 27573,
+        "recipientId": 90495,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/490/200/200",
+        "relationship": "가족",
+        "content": "이영준님의 메세지 내용 64",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-06-17T05:10:47Z"
+      },
+      {
+        "id": 96157,
+        "recipientId": 90495,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/75/200/200",
+        "relationship": "친구",
+        "content": "최민수님의 메세지 내용 30",
+        "font": "Noto Sans",
+        "createdAt": "2023-03-11T02:09:50Z"
+      },
+      {
+        "id": 39533,
+        "recipientId": 90495,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/436/200/200",
+        "relationship": "동료",
+        "content": "이영준님의 메세지 내용 38",
+        "font": "Roboto",
+        "createdAt": "2023-03-15T20:24:49Z"
+      }
+    ],
+    "reactionCount": 0,
+    "topReactions": [
+      {
+        "id": 99864,
+        "emoji": "🥹",
+        "count": 11
+      }
+    ]
+  },
+  {
+    "id": 83558,
+    "name": "한지민",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/83558/600/400",
+    "createdAt": "2023-03-30T04:18:29Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 91701,
+        "recipientId": 83558,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/169/200/200",
+        "relationship": "지인",
+        "content": "이병헌님의 메세지 내용 97",
+        "font": "Noto Sans",
+        "createdAt": "2023-11-22T09:50:03Z"
+      },
+      {
+        "id": 23330,
+        "recipientId": 83558,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/8/200/200",
+        "relationship": "지인",
+        "content": "한지민님의 메세지 내용 77",
+        "font": "Noto Sans",
+        "createdAt": "2024-01-04T23:36:01Z"
+      },
+      {
+        "id": 79589,
+        "recipientId": 83558,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/472/200/200",
+        "relationship": "친구",
+        "content": "한지민님의 메세지 내용 24",
+        "font": "Pretendard",
+        "createdAt": "2023-01-02T22:24:57Z"
+      }
+    ],
+    "reactionCount": 95,
+    "topReactions": [
+      {
+        "id": 4780,
+        "emoji": "😀",
+        "count": 11
+      },
+      {
+        "id": 36370,
+        "emoji": "👍",
+        "count": 15
+      },
+      {
+        "id": 857,
+        "emoji": "😁",
+        "count": 11
+      },
+      {
+        "id": 68373,
+        "emoji": "😁",
+        "count": 17
+      },
+      {
+        "id": 86784,
+        "emoji": "❤️",
+        "count": 20
+      }
+    ]
+  },
+  {
+    "id": 66320,
+    "name": "전지현",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-02-20T16:11:28Z",
+    "messageCount": 6,
+    "recentMessages": [
+      {
+        "id": 2994,
+        "recipientId": 66320,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/84/200/200",
+        "relationship": "동료",
+        "content": "이영준님의 메세지 내용 2",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-08-27T10:17:50Z"
+      },
+      {
+        "id": 56137,
+        "recipientId": 66320,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/1/200/200",
+        "relationship": "가족",
+        "content": "송혜교님의 메세지 내용 56",
+        "font": "Noto Sans",
+        "createdAt": "2023-08-10T23:57:30Z"
+      },
+      {
+        "id": 53043,
+        "recipientId": 66320,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/48/200/200",
+        "relationship": "동료",
+        "content": "송혜교님의 메세지 내용 5",
+        "font": "Noto Sans",
+        "createdAt": "2024-01-18T11:22:58Z"
+      }
+    ],
+    "reactionCount": 63,
+    "topReactions": [
+      {
+        "id": 48182,
+        "emoji": "😀",
+        "count": 16
+      },
+      {
+        "id": 5086,
+        "emoji": "😀",
+        "count": 9
+      },
+      {
+        "id": 3495,
+        "emoji": "❤️",
+        "count": 5
+      },
+      {
+        "id": 84837,
+        "emoji": "🥹",
+        "count": 6
+      }
+    ]
+  },
+  {
+    "id": 1220,
+    "name": "김하은",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/1220/600/400",
+    "createdAt": "2023-11-08T12:25:25Z",
+    "messageCount": 1,
+    "recentMessages": [
+      {
+        "id": 86215,
+        "recipientId": 1220,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/419/200/200",
+        "relationship": "가족",
+        "content": "이병헌님의 메세지 내용 25",
+        "font": "Pretendard",
+        "createdAt": "2023-05-10T21:59:12Z"
+      }
+    ],
+    "reactionCount": 14,
+    "topReactions": [
+      {
+        "id": 11863,
+        "emoji": "👍",
+        "count": 16
+      },
+      {
+        "id": 36179,
+        "emoji": "🎉",
+        "count": 18
+      }
+    ]
+  },
+  {
+    "id": 53959,
+    "name": "이병헌",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/53959/600/400",
+    "createdAt": "2023-08-24T05:22:48Z",
+    "messageCount": 7,
+    "recentMessages": [
+      {
+        "id": 84022,
+        "recipientId": 53959,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/199/200/200",
+        "relationship": "지인",
+        "content": "현빈님의 메세지 내용 71",
+        "font": "Nanum Gothic",
+        "createdAt": "2024-01-27T22:35:29Z"
+      },
+      {
+        "id": 29280,
+        "recipientId": 53959,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/415/200/200",
+        "relationship": "동료",
+        "content": "이영준님의 메세지 내용 73",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-02-08T09:24:01Z"
+      },
+      {
+        "id": 59151,
+        "recipientId": 53959,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/10/200/200",
+        "relationship": "친구",
+        "content": "이병헌님의 메세지 내용 4",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-03-11T07:04:18Z"
+      }
+    ],
+    "reactionCount": 24,
+    "topReactions": [
+      {
+        "id": 23239,
+        "emoji": "🥹",
+        "count": 6
+      },
+      {
+        "id": 8346,
+        "emoji": "😀",
+        "count": 3
+      },
+      {
+        "id": 10520,
+        "emoji": "❤️",
+        "count": 9
+      },
+      {
+        "id": 92010,
+        "emoji": "😀",
+        "count": 9
+      },
+      {
+        "id": 33511,
+        "emoji": "🥹",
+        "count": 11
+      },
+      {
+        "id": 29961,
+        "emoji": "😀",
+        "count": 17
+      }
+    ]
+  },
+  {
+    "id": 21491,
+    "name": "박서준",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/21491/600/400",
+    "createdAt": "2023-01-10T01:44:28Z",
+    "messageCount": 5,
+    "recentMessages": [
+      {
+        "id": 84576,
+        "recipientId": 21491,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/409/200/200",
+        "relationship": "동료",
+        "content": "김하은님의 메세지 내용 59",
+        "font": "Pretendard",
+        "createdAt": "2023-11-01T08:41:35Z"
+      },
+      {
+        "id": 18967,
+        "recipientId": 21491,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/330/200/200",
+        "relationship": "가족",
+        "content": "현빈님의 메세지 내용 86",
+        "font": "Pretendard",
+        "createdAt": "2024-01-30T16:01:34Z"
+      },
+      {
+        "id": 89384,
+        "recipientId": 21491,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/467/200/200",
+        "relationship": "동료",
+        "content": "정우성님의 메세지 내용 88",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-09-04T20:05:02Z"
+      }
+    ],
+    "reactionCount": 8,
+    "topReactions": [
+      {
+        "id": 78078,
+        "emoji": "👍",
+        "count": 2
+      },
+      {
+        "id": 36649,
+        "emoji": "🎉",
+        "count": 6
+      },
+      {
+        "id": 92725,
+        "emoji": "❤️",
+        "count": 2
+      }
+    ]
+  },
+  {
+    "id": 51432,
+    "name": "이병헌",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/51432/600/400",
+    "createdAt": "2023-11-07T07:07:37Z",
+    "messageCount": 5,
+    "recentMessages": [
+      {
+        "id": 96527,
+        "recipientId": 51432,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/119/200/200",
+        "relationship": "친구",
+        "content": "이영준님의 메세지 내용 28",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-12-01T00:14:54Z"
+      },
+      {
+        "id": 33808,
+        "recipientId": 51432,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/478/200/200",
+        "relationship": "친구",
+        "content": "이병헌님의 메세지 내용 8",
+        "font": "Pretendard",
+        "createdAt": "2023-04-04T10:06:15Z"
+      },
+      {
+        "id": 65182,
+        "recipientId": 51432,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/417/200/200",
+        "relationship": "친구",
+        "content": "한지민님의 메세지 내용 65",
+        "font": "Noto Sans",
+        "createdAt": "2023-07-31T00:30:43Z"
+      }
+    ],
+    "reactionCount": 12,
+    "topReactions": [
+      {
+        "id": 45279,
+        "emoji": "🥹",
+        "count": 4
+      },
+      {
+        "id": 59474,
+        "emoji": "👍",
+        "count": 11
+      },
+      {
+        "id": 61205,
+        "emoji": "👍",
+        "count": 20
+      },
+      {
+        "id": 69208,
+        "emoji": "😀",
+        "count": 11
+      },
+      {
+        "id": 47277,
+        "emoji": "🎉",
+        "count": 13
+      }
+    ]
+  },
+  {
+    "id": 401,
+    "name": "전지현",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/401/600/400",
+    "createdAt": "2024-01-28T02:15:08Z",
+    "messageCount": 5,
+    "recentMessages": [
+      {
+        "id": 36776,
+        "recipientId": 401,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/194/200/200",
+        "relationship": "친구",
+        "content": "현빈님의 메세지 내용 6",
+        "font": "Pretendard",
+        "createdAt": "2023-10-03T09:11:41Z"
+      },
+      {
+        "id": 62441,
+        "recipientId": 401,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/276/200/200",
+        "relationship": "지인",
+        "content": "현빈님의 메세지 내용 83",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-07-27T15:25:12Z"
+      },
+      {
+        "id": 50507,
+        "recipientId": 401,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/174/200/200",
+        "relationship": "동료",
+        "content": "이영준님의 메세지 내용 71",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-08-26T17:23:07Z"
+      }
+    ],
+    "reactionCount": 96,
+    "topReactions": [
+      {
+        "id": 49415,
+        "emoji": "😀",
+        "count": 16
+      }
+    ]
+  },
+  {
+    "id": 46242,
+    "name": "송혜교",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/46242/600/400",
+    "createdAt": "2023-11-05T16:41:50Z",
+    "messageCount": 1,
+    "recentMessages": [
+      {
+        "id": 60128,
+        "recipientId": 46242,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/149/200/200",
+        "relationship": "지인",
+        "content": "김하은님의 메세지 내용 97",
+        "font": "Roboto",
+        "createdAt": "2023-09-25T08:24:21Z"
+      }
+    ],
+    "reactionCount": 61,
+    "topReactions": [
+      {
+        "id": 78077,
+        "emoji": "❤️",
+        "count": 15
+      },
+      {
+        "id": 81214,
+        "emoji": "🥹",
+        "count": 6
+      },
+      {
+        "id": 17360,
+        "emoji": "❤️",
+        "count": 19
+      },
+      {
+        "id": 21652,
+        "emoji": "🥹",
+        "count": 4
+      }
+    ]
+  },
+  {
+    "id": 55794,
+    "name": "전지현",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/55794/600/400",
+    "createdAt": "2023-05-13T18:46:52Z",
+    "messageCount": 10,
+    "recentMessages": [
+      {
+        "id": 2249,
+        "recipientId": 55794,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/443/200/200",
+        "relationship": "가족",
+        "content": "이영준님의 메세지 내용 70",
+        "font": "Roboto",
+        "createdAt": "2023-05-25T22:41:35Z"
+      },
+      {
+        "id": 71265,
+        "recipientId": 55794,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/18/200/200",
+        "relationship": "친구",
+        "content": "송혜교님의 메세지 내용 47",
+        "font": "Roboto",
+        "createdAt": "2023-04-15T12:50:11Z"
+      },
+      {
+        "id": 18226,
+        "recipientId": 55794,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/173/200/200",
+        "relationship": "가족",
+        "content": "송혜교님의 메세지 내용 35",
+        "font": "Pretendard",
+        "createdAt": "2023-02-21T23:19:58Z"
+      }
+    ],
+    "reactionCount": 77,
+    "topReactions": [
+      {
+        "id": 52469,
+        "emoji": "❤️",
+        "count": 16
+      }
+    ]
+  },
+  {
+    "id": 14085,
+    "name": "박서준",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/14085/600/400",
+    "createdAt": "2023-09-25T12:01:08Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 25819,
+        "recipientId": 14085,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/222/200/200",
+        "relationship": "가족",
+        "content": "전지현님의 메세지 내용 39",
+        "font": "Roboto",
+        "createdAt": "2023-08-12T06:36:32Z"
+      },
+      {
+        "id": 73459,
+        "recipientId": 14085,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/160/200/200",
+        "relationship": "지인",
+        "content": "전지현님의 메세지 내용 89",
+        "font": "Roboto",
+        "createdAt": "2023-08-08T03:12:04Z"
+      },
+      {
+        "id": 11457,
+        "recipientId": 14085,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/151/200/200",
+        "relationship": "지인",
+        "content": "현빈님의 메세지 내용 23",
+        "font": "Roboto",
+        "createdAt": "2023-01-11T18:53:34Z"
+      }
+    ],
+    "reactionCount": 33,
+    "topReactions": [
+      {
+        "id": 41010,
+        "emoji": "🥹",
+        "count": 14
+      }
+    ]
+  },
+  {
+    "id": 96101,
+    "name": "송혜교",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/96101/600/400",
+    "createdAt": "2023-05-16T19:22:33Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 8754,
+        "recipientId": 96101,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/31/200/200",
+        "relationship": "동료",
+        "content": "전지현님의 메세지 내용 8",
+        "font": "Nanum Gothic",
+        "createdAt": "2024-01-30T09:22:34Z"
+      },
+      {
+        "id": 83212,
+        "recipientId": 96101,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/276/200/200",
+        "relationship": "동료",
+        "content": "현빈님의 메세지 내용 10",
+        "font": "Pretendard",
+        "createdAt": "2023-11-29T06:01:50Z"
+      },
+      {
+        "id": 97718,
+        "recipientId": 96101,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/76/200/200",
+        "relationship": "동료",
+        "content": "전지현님의 메세지 내용 93",
+        "font": "Pretendard",
+        "createdAt": "2023-07-19T21:00:40Z"
+      }
+    ],
+    "reactionCount": 86,
+    "topReactions": [
+      {
+        "id": 42848,
+        "emoji": "🥹",
+        "count": 4
+      },
+      {
+        "id": 30829,
+        "emoji": "🎉",
+        "count": 5
+      },
+      {
+        "id": 89207,
+        "emoji": "😁",
+        "count": 11
+      },
+      {
+        "id": 82766,
+        "emoji": "😀",
+        "count": 7
+      },
+      {
+        "id": 95876,
+        "emoji": "🎉",
+        "count": 6
+      }
+    ]
+  },
+  {
+    "id": 34177,
+    "name": "송혜교",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/34177/600/400",
+    "createdAt": "2023-01-14T02:09:25Z",
+    "messageCount": 9,
+    "recentMessages": [
+      {
+        "id": 67802,
+        "recipientId": 34177,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/498/200/200",
+        "relationship": "가족",
+        "content": "정우성님의 메세지 내용 23",
+        "font": "Pretendard",
+        "createdAt": "2023-05-17T08:09:24Z"
+      },
+      {
+        "id": 71447,
+        "recipientId": 34177,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/372/200/200",
+        "relationship": "친구",
+        "content": "최민수님의 메세지 내용 52",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-06-17T03:43:25Z"
+      },
+      {
+        "id": 55931,
+        "recipientId": 34177,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/385/200/200",
+        "relationship": "가족",
+        "content": "한지민님의 메세지 내용 89",
+        "font": "Noto Sans",
+        "createdAt": "2023-01-13T07:49:49Z"
+      }
+    ],
+    "reactionCount": 43,
+    "topReactions": [
+      {
+        "id": 70355,
+        "emoji": "🎉",
+        "count": 8
+      },
+      {
+        "id": 23001,
+        "emoji": "😁",
+        "count": 16
+      },
+      {
+        "id": 16865,
+        "emoji": "🎉",
+        "count": 20
+      },
+      {
+        "id": 85383,
+        "emoji": "👍",
+        "count": 1
+      },
+      {
+        "id": 62476,
+        "emoji": "👍",
+        "count": 2
+      },
+      {
+        "id": 25834,
+        "emoji": "👍",
+        "count": 1
+      }
+    ]
+  },
+  {
+    "id": 36016,
+    "name": "정우성",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2023-11-15T11:01:43Z",
+    "messageCount": 2,
+    "recentMessages": [
+      {
+        "id": 36042,
+        "recipientId": 36016,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/140/200/200",
+        "relationship": "지인",
+        "content": "현빈님의 메세지 내용 42",
+        "font": "Noto Sans",
+        "createdAt": "2023-04-26T16:56:26Z"
+      },
+      {
+        "id": 98913,
+        "recipientId": 36016,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/439/200/200",
+        "relationship": "동료",
+        "content": "이영준님의 메세지 내용 98",
+        "font": "Roboto",
+        "createdAt": "2023-04-04T05:29:41Z"
+      }
+    ],
+    "reactionCount": 51,
+    "topReactions": [
+      {
+        "id": 79191,
+        "emoji": "😀",
+        "count": 17
+      },
+      {
+        "id": 99981,
+        "emoji": "😀",
+        "count": 7
+      },
+      {
+        "id": 77927,
+        "emoji": "🎉",
+        "count": 4
+      }
+    ]
+  },
+  {
+    "id": 43594,
+    "name": "김하은",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2023-11-09T19:23:06Z",
+    "messageCount": 5,
+    "recentMessages": [
+      {
+        "id": 42515,
+        "recipientId": 43594,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/458/200/200",
+        "relationship": "동료",
+        "content": "최민수님의 메세지 내용 27",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-08-31T23:26:56Z"
+      },
+      {
+        "id": 13825,
+        "recipientId": 43594,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/331/200/200",
+        "relationship": "지인",
+        "content": "한지민님의 메세지 내용 29",
+        "font": "Noto Sans",
+        "createdAt": "2023-12-05T11:12:30Z"
+      },
+      {
+        "id": 5602,
+        "recipientId": 43594,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/430/200/200",
+        "relationship": "친구",
+        "content": "김하은님의 메세지 내용 99",
+        "font": "Pretendard",
+        "createdAt": "2023-05-05T13:59:19Z"
+      }
+    ],
+    "reactionCount": 13,
+    "topReactions": [
+      {
+        "id": 22643,
+        "emoji": "👍",
+        "count": 19
+      },
+      {
+        "id": 77117,
+        "emoji": "😁",
+        "count": 8
+      },
+      {
+        "id": 35930,
+        "emoji": "❤️",
+        "count": 8
+      },
+      {
+        "id": 86858,
+        "emoji": "🎉",
+        "count": 16
+      }
+    ]
+  },
+  {
+    "id": 73798,
+    "name": "한지민",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/73798/600/400",
+    "createdAt": "2023-11-07T13:40:42Z",
+    "messageCount": 7,
+    "recentMessages": [
+      {
+        "id": 33420,
+        "recipientId": 73798,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/297/200/200",
+        "relationship": "동료",
+        "content": "박서준님의 메세지 내용 34",
+        "font": "Roboto",
+        "createdAt": "2023-04-26T15:23:15Z"
+      },
+      {
+        "id": 93059,
+        "recipientId": 73798,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/252/200/200",
+        "relationship": "지인",
+        "content": "이병헌님의 메세지 내용 99",
+        "font": "Roboto",
+        "createdAt": "2023-11-21T09:01:45Z"
+      },
+      {
+        "id": 56278,
+        "recipientId": 73798,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/102/200/200",
+        "relationship": "지인",
+        "content": "송혜교님의 메세지 내용 9",
+        "font": "Roboto",
+        "createdAt": "2024-01-17T01:00:57Z"
+      }
+    ],
+    "reactionCount": 71,
+    "topReactions": [
+      {
+        "id": 31784,
+        "emoji": "😁",
+        "count": 6
+      },
+      {
+        "id": 52139,
+        "emoji": "🥹",
+        "count": 7
+      },
+      {
+        "id": 20530,
+        "emoji": "😁",
+        "count": 9
+      },
+      {
+        "id": 12585,
+        "emoji": "👍",
+        "count": 11
+      },
+      {
+        "id": 6677,
+        "emoji": "❤️",
+        "count": 6
+      }
+    ]
+  },
+  {
+    "id": 36247,
+    "name": "전지현",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-03-31T09:45:14Z",
+    "messageCount": 5,
+    "recentMessages": [
+      {
+        "id": 7590,
+        "recipientId": 36247,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/419/200/200",
+        "relationship": "동료",
+        "content": "박서준님의 메세지 내용 79",
+        "font": "Roboto",
+        "createdAt": "2023-12-24T23:43:44Z"
+      },
+      {
+        "id": 93972,
+        "recipientId": 36247,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/239/200/200",
+        "relationship": "동료",
+        "content": "박서준님의 메세지 내용 75",
+        "font": "Roboto",
+        "createdAt": "2024-01-29T06:48:53Z"
+      },
+      {
+        "id": 50155,
+        "recipientId": 36247,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/24/200/200",
+        "relationship": "지인",
+        "content": "한지민님의 메세지 내용 5",
+        "font": "Pretendard",
+        "createdAt": "2023-09-29T15:59:52Z"
+      }
+    ],
+    "reactionCount": 53,
+    "topReactions": [
+      {
+        "id": 16359,
+        "emoji": "😁",
+        "count": 4
+      },
+      {
+        "id": 63702,
+        "emoji": "😁",
+        "count": 11
+      },
+      {
+        "id": 74672,
+        "emoji": "😁",
+        "count": 18
+      }
+    ]
+  },
+  {
+    "id": 3992,
+    "name": "전지현",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2023-01-07T22:06:39Z",
+    "messageCount": 9,
+    "recentMessages": [
+      {
+        "id": 92492,
+        "recipientId": 3992,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/20/200/200",
+        "relationship": "지인",
+        "content": "최민수님의 메세지 내용 70",
+        "font": "Noto Sans",
+        "createdAt": "2023-05-09T01:45:03Z"
+      },
+      {
+        "id": 33941,
+        "recipientId": 3992,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/364/200/200",
+        "relationship": "친구",
+        "content": "이병헌님의 메세지 내용 93",
+        "font": "Pretendard",
+        "createdAt": "2023-02-13T23:03:26Z"
+      },
+      {
+        "id": 86140,
+        "recipientId": 3992,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/276/200/200",
+        "relationship": "친구",
+        "content": "현빈님의 메세지 내용 22",
+        "font": "Pretendard",
+        "createdAt": "2023-05-26T22:01:31Z"
+      }
+    ],
+    "reactionCount": 28,
+    "topReactions": [
+      {
+        "id": 59388,
+        "emoji": "🎉",
+        "count": 4
+      }
+    ]
+  },
+  {
+    "id": 55254,
+    "name": "이영준",
+    "backgroundColor": "green",
+    "backgroundImageURL": null,
+    "createdAt": "2023-04-20T01:09:02Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 34003,
+        "recipientId": 55254,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/482/200/200",
+        "relationship": "가족",
+        "content": "한지민님의 메세지 내용 83",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-07-15T10:19:57Z"
+      },
+      {
+        "id": 79633,
+        "recipientId": 55254,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/187/200/200",
+        "relationship": "지인",
+        "content": "최민수님의 메세지 내용 63",
+        "font": "Roboto",
+        "createdAt": "2023-11-14T17:55:45Z"
+      },
+      {
+        "id": 10233,
+        "recipientId": 55254,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/491/200/200",
+        "relationship": "가족",
+        "content": "최민수님의 메세지 내용 26",
+        "font": "Roboto",
+        "createdAt": "2023-06-23T02:56:08Z"
+      }
+    ],
+    "reactionCount": 43,
+    "topReactions": [
+      {
+        "id": 3962,
+        "emoji": "🥹",
+        "count": 17
+      }
+    ]
+  },
+  {
+    "id": 63758,
+    "name": "정우성",
+    "backgroundColor": "blue",
+    "backgroundImageURL": null,
+    "createdAt": "2023-06-21T03:01:01Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 90458,
+        "recipientId": 63758,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/111/200/200",
+        "relationship": "동료",
+        "content": "정우성님의 메세지 내용 49",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-05-12T19:29:28Z"
+      },
+      {
+        "id": 89359,
+        "recipientId": 63758,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/401/200/200",
+        "relationship": "지인",
+        "content": "이병헌님의 메세지 내용 53",
+        "font": "Roboto",
+        "createdAt": "2023-05-10T19:04:15Z"
+      },
+      {
+        "id": 57663,
+        "recipientId": 63758,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/215/200/200",
+        "relationship": "가족",
+        "content": "최민수님의 메세지 내용 87",
+        "font": "Roboto",
+        "createdAt": "2023-05-27T20:40:23Z"
+      }
+    ],
+    "reactionCount": 56,
+    "topReactions": [
+      {
+        "id": 52289,
+        "emoji": "😁",
+        "count": 7
+      }
+    ]
+  },
+  {
+    "id": 63073,
+    "name": "최민수",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2023-07-13T16:42:26Z",
+    "messageCount": 1,
+    "recentMessages": [
+      {
+        "id": 60054,
+        "recipientId": 63073,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/46/200/200",
+        "relationship": "지인",
+        "content": "전지현님의 메세지 내용 69",
+        "font": "Noto Sans",
+        "createdAt": "2023-01-01T10:21:56Z"
+      }
+    ],
+    "reactionCount": 69,
+    "topReactions": [
+      {
+        "id": 75660,
+        "emoji": "🥹",
+        "count": 13
+      },
+      {
+        "id": 30629,
+        "emoji": "❤️",
+        "count": 6
+      }
+    ]
+  },
+  {
+    "id": 66658,
+    "name": "최민수",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/66658/600/400",
+    "createdAt": "2023-07-23T23:50:37Z",
+    "messageCount": 10,
+    "recentMessages": [
+      {
+        "id": 25811,
+        "recipientId": 66658,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/417/200/200",
+        "relationship": "동료",
+        "content": "박서준님의 메세지 내용 98",
+        "font": "Roboto",
+        "createdAt": "2023-06-18T13:53:21Z"
+      },
+      {
+        "id": 7862,
+        "recipientId": 66658,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/188/200/200",
+        "relationship": "지인",
+        "content": "이영준님의 메세지 내용 8",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-07-07T23:55:45Z"
+      },
+      {
+        "id": 16602,
+        "recipientId": 66658,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/446/200/200",
+        "relationship": "지인",
+        "content": "박서준님의 메세지 내용 44",
+        "font": "Pretendard",
+        "createdAt": "2023-03-24T18:20:49Z"
+      }
+    ],
+    "reactionCount": 26,
+    "topReactions": [
+      {
+        "id": 68634,
+        "emoji": "👍",
+        "count": 16
+      },
+      {
+        "id": 74041,
+        "emoji": "🥹",
+        "count": 12
+      },
+      {
+        "id": 834,
+        "emoji": "🥹",
+        "count": 5
+      }
+    ]
+  },
+  {
+    "id": 63096,
+    "name": "이병헌",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/63096/600/400",
+    "createdAt": "2023-08-25T09:30:08Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 72995,
+        "recipientId": 63096,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/368/200/200",
+        "relationship": "동료",
+        "content": "이병헌님의 메세지 내용 44",
+        "font": "Pretendard",
+        "createdAt": "2023-10-07T18:41:59Z"
+      },
+      {
+        "id": 54115,
+        "recipientId": 63096,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/335/200/200",
+        "relationship": "친구",
+        "content": "박서준님의 메세지 내용 41",
+        "font": "Roboto",
+        "createdAt": "2023-11-02T10:19:13Z"
+      },
+      {
+        "id": 56992,
+        "recipientId": 63096,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/482/200/200",
+        "relationship": "친구",
+        "content": "최민수님의 메세지 내용 30",
+        "font": "Pretendard",
+        "createdAt": "2023-12-30T21:02:26Z"
+      }
+    ],
+    "reactionCount": 90,
+    "topReactions": [
+      {
+        "id": 30117,
+        "emoji": "🎉",
+        "count": 14
+      },
+      {
+        "id": 52187,
+        "emoji": "👍",
+        "count": 6
+      },
+      {
+        "id": 18011,
+        "emoji": "🎉",
+        "count": 17
+      }
+    ]
+  },
+  {
+    "id": 13289,
+    "name": "박서준",
+    "backgroundColor": "green",
+    "backgroundImageURL": null,
+    "createdAt": "2023-12-04T12:58:18Z",
+    "messageCount": 3,
+    "recentMessages": [
+      {
+        "id": 44494,
+        "recipientId": 13289,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/118/200/200",
+        "relationship": "친구",
+        "content": "이병헌님의 메세지 내용 64",
+        "font": "Nanum Gothic",
+        "createdAt": "2024-01-29T16:37:33Z"
+      },
+      {
+        "id": 13927,
+        "recipientId": 13289,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/328/200/200",
+        "relationship": "동료",
+        "content": "김하은님의 메세지 내용 31",
+        "font": "Noto Sans",
+        "createdAt": "2023-02-23T01:04:06Z"
+      },
+      {
+        "id": 11952,
+        "recipientId": 13289,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/205/200/200",
+        "relationship": "지인",
+        "content": "최민수님의 메세지 내용 11",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-05-25T08:12:10Z"
+      }
+    ],
+    "reactionCount": 20,
+    "topReactions": [
+      {
+        "id": 27582,
+        "emoji": "🥹",
+        "count": 5
+      },
+      {
+        "id": 7453,
+        "emoji": "😁",
+        "count": 15
+      },
+      {
+        "id": 32011,
+        "emoji": "🥹",
+        "count": 14
+      },
+      {
+        "id": 18525,
+        "emoji": "🎉",
+        "count": 8
+      },
+      {
+        "id": 15768,
+        "emoji": "😀",
+        "count": 19
+      },
+      {
+        "id": 14938,
+        "emoji": "👍",
+        "count": 6
+      }
+    ]
+  },
+  {
+    "id": 39580,
+    "name": "송혜교",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/39580/600/400",
+    "createdAt": "2023-08-16T00:55:39Z",
+    "messageCount": 6,
+    "recentMessages": [
+      {
+        "id": 27255,
+        "recipientId": 39580,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/195/200/200",
+        "relationship": "동료",
+        "content": "김하은님의 메세지 내용 1",
+        "font": "Roboto",
+        "createdAt": "2023-01-01T19:38:10Z"
+      },
+      {
+        "id": 63506,
+        "recipientId": 39580,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/120/200/200",
+        "relationship": "동료",
+        "content": "현빈님의 메세지 내용 13",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-09-14T22:10:26Z"
+      },
+      {
+        "id": 55735,
+        "recipientId": 39580,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/437/200/200",
+        "relationship": "친구",
+        "content": "현빈님의 메세지 내용 54",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-09-07T03:32:34Z"
+      }
+    ],
+    "reactionCount": 63,
+    "topReactions": [
+      {
+        "id": 75593,
+        "emoji": "🎉",
+        "count": 17
+      },
+      {
+        "id": 86152,
+        "emoji": "👍",
+        "count": 18
+      },
+      {
+        "id": 94679,
+        "emoji": "❤️",
+        "count": 19
+      },
+      {
+        "id": 93225,
+        "emoji": "😁",
+        "count": 3
+      },
+      {
+        "id": 50484,
+        "emoji": "🎉",
+        "count": 9
+      },
+      {
+        "id": 97858,
+        "emoji": "👍",
+        "count": 2
+      }
+    ]
+  },
+  {
+    "id": 57125,
+    "name": "전지현",
+    "backgroundColor": "blue",
+    "backgroundImageURL": null,
+    "createdAt": "2023-02-18T07:04:21Z",
+    "messageCount": 6,
+    "recentMessages": [
+      {
+        "id": 91193,
+        "recipientId": 57125,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/448/200/200",
+        "relationship": "동료",
+        "content": "송혜교님의 메세지 내용 49",
+        "font": "Pretendard",
+        "createdAt": "2023-06-20T16:12:07Z"
+      },
+      {
+        "id": 77931,
+        "recipientId": 57125,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/486/200/200",
+        "relationship": "지인",
+        "content": "한지민님의 메세지 내용 94",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-12-29T17:04:41Z"
+      },
+      {
+        "id": 41786,
+        "recipientId": 57125,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/39/200/200",
+        "relationship": "친구",
+        "content": "이영준님의 메세지 내용 84",
+        "font": "Pretendard",
+        "createdAt": "2023-07-15T19:00:07Z"
+      }
+    ],
+    "reactionCount": 98,
+    "topReactions": [
+      {
+        "id": 11291,
+        "emoji": "🥹",
+        "count": 9
+      },
+      {
+        "id": 71787,
+        "emoji": "😀",
+        "count": 19
+      }
+    ]
+  },
+  {
+    "id": 94817,
+    "name": "최민수",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/94817/600/400",
+    "createdAt": "2023-05-07T10:26:03Z",
+    "messageCount": 7,
+    "recentMessages": [
+      {
+        "id": 84068,
+        "recipientId": 94817,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/186/200/200",
+        "relationship": "동료",
+        "content": "박서준님의 메세지 내용 35",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-10-16T23:50:30Z"
+      },
+      {
+        "id": 16638,
+        "recipientId": 94817,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/11/200/200",
+        "relationship": "친구",
+        "content": "김하은님의 메세지 내용 51",
+        "font": "Roboto",
+        "createdAt": "2023-12-31T02:34:22Z"
+      },
+      {
+        "id": 19857,
+        "recipientId": 94817,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/364/200/200",
+        "relationship": "동료",
+        "content": "전지현님의 메세지 내용 87",
+        "font": "Pretendard",
+        "createdAt": "2023-04-01T17:28:06Z"
+      }
+    ],
+    "reactionCount": 69,
+    "topReactions": [
+      {
+        "id": 29485,
+        "emoji": "😁",
+        "count": 16
+      },
+      {
+        "id": 51258,
+        "emoji": "😁",
+        "count": 14
+      },
+      {
+        "id": 24027,
+        "emoji": "😁",
+        "count": 18
+      },
+      {
+        "id": 86629,
+        "emoji": "😀",
+        "count": 4
+      }
+    ]
+  },
+  {
+    "id": 8900,
+    "name": "박서준",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/8900/600/400",
+    "createdAt": "2023-08-06T08:59:01Z",
+    "messageCount": 1,
+    "recentMessages": [
+      {
+        "id": 54900,
+        "recipientId": 8900,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/448/200/200",
+        "relationship": "지인",
+        "content": "현빈님의 메세지 내용 91",
+        "font": "Pretendard",
+        "createdAt": "2023-10-16T00:46:38Z"
+      }
+    ],
+    "reactionCount": 52,
+    "topReactions": [
+      {
+        "id": 78028,
+        "emoji": "👍",
+        "count": 7
+      },
+      {
+        "id": 81658,
+        "emoji": "👍",
+        "count": 8
+      },
+      {
+        "id": 99396,
+        "emoji": "❤️",
+        "count": 1
+      },
+      {
+        "id": 91845,
+        "emoji": "🎉",
+        "count": 4
+      },
+      {
+        "id": 95208,
+        "emoji": "👍",
+        "count": 5
+      }
+    ]
+  },
+  {
+    "id": 3922,
+    "name": "박서준",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/3922/600/400",
+    "createdAt": "2023-10-23T08:41:22Z",
+    "messageCount": 2,
+    "recentMessages": [
+      {
+        "id": 99355,
+        "recipientId": 3922,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/125/200/200",
+        "relationship": "친구",
+        "content": "전지현님의 메세지 내용 62",
+        "font": "Pretendard",
+        "createdAt": "2023-09-14T05:24:27Z"
+      },
+      {
+        "id": 34171,
+        "recipientId": 3922,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/154/200/200",
+        "relationship": "친구",
+        "content": "이영준님의 메세지 내용 28",
+        "font": "Pretendard",
+        "createdAt": "2023-08-04T22:53:11Z"
+      }
+    ],
+    "reactionCount": 55,
+    "topReactions": [
+      {
+        "id": 63963,
+        "emoji": "😀",
+        "count": 11
+      },
+      {
+        "id": 26888,
+        "emoji": "😀",
+        "count": 14
+      },
+      {
+        "id": 5147,
+        "emoji": "😁",
+        "count": 15
+      },
+      {
+        "id": 47112,
+        "emoji": "❤️",
+        "count": 7
+      }
+    ]
+  },
+  {
+    "id": 66190,
+    "name": "전지현",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-07-08T04:47:00Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 17000,
+        "recipientId": 66190,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/498/200/200",
+        "relationship": "동료",
+        "content": "이영준님의 메세지 내용 26",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-07-12T15:08:11Z"
+      },
+      {
+        "id": 65326,
+        "recipientId": 66190,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/286/200/200",
+        "relationship": "동료",
+        "content": "한지민님의 메세지 내용 43",
+        "font": "Noto Sans",
+        "createdAt": "2023-04-14T16:41:19Z"
+      },
+      {
+        "id": 33150,
+        "recipientId": 66190,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/26/200/200",
+        "relationship": "지인",
+        "content": "이병헌님의 메세지 내용 47",
+        "font": "Roboto",
+        "createdAt": "2024-01-22T00:03:15Z"
+      }
+    ],
+    "reactionCount": 29,
+    "topReactions": [
+      {
+        "id": 30808,
+        "emoji": "🥹",
+        "count": 20
+      },
+      {
+        "id": 18642,
+        "emoji": "😀",
+        "count": 9
+      }
+    ]
+  },
+  {
+    "id": 68635,
+    "name": "이병헌",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-10-22T10:14:45Z",
+    "messageCount": 5,
+    "recentMessages": [
+      {
+        "id": 97206,
+        "recipientId": 68635,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/26/200/200",
+        "relationship": "친구",
+        "content": "김하은님의 메세지 내용 2",
+        "font": "Roboto",
+        "createdAt": "2023-08-28T16:03:45Z"
+      },
+      {
+        "id": 37796,
+        "recipientId": 68635,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/203/200/200",
+        "relationship": "친구",
+        "content": "박서준님의 메세지 내용 68",
+        "font": "Pretendard",
+        "createdAt": "2023-01-17T12:45:37Z"
+      },
+      {
+        "id": 40502,
+        "recipientId": 68635,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/40/200/200",
+        "relationship": "지인",
+        "content": "송혜교님의 메세지 내용 71",
+        "font": "Roboto",
+        "createdAt": "2023-05-14T12:47:53Z"
+      }
+    ],
+    "reactionCount": 18,
+    "topReactions": [
+      {
+        "id": 98726,
+        "emoji": "😀",
+        "count": 15
+      },
+      {
+        "id": 65169,
+        "emoji": "🥹",
+        "count": 3
+      },
+      {
+        "id": 8481,
+        "emoji": "🥹",
+        "count": 12
+      }
+    ]
+  },
+  {
+    "id": 52236,
+    "name": "현빈",
+    "backgroundColor": "blue",
+    "backgroundImageURL": null,
+    "createdAt": "2024-01-07T08:24:21Z",
+    "messageCount": 1,
+    "recentMessages": [
+      {
+        "id": 8378,
+        "recipientId": 52236,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/383/200/200",
+        "relationship": "동료",
+        "content": "이병헌님의 메세지 내용 53",
+        "font": "Pretendard",
+        "createdAt": "2023-12-03T19:03:51Z"
+      }
+    ],
+    "reactionCount": 48,
+    "topReactions": [
+      {
+        "id": 89637,
+        "emoji": "😀",
+        "count": 8
+      }
+    ]
+  },
+  {
+    "id": 81115,
+    "name": "전지현",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/81115/600/400",
+    "createdAt": "2023-06-05T18:41:55Z",
+    "messageCount": 7,
+    "recentMessages": [
+      {
+        "id": 97959,
+        "recipientId": 81115,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/187/200/200",
+        "relationship": "지인",
+        "content": "정우성님의 메세지 내용 26",
+        "font": "Roboto",
+        "createdAt": "2023-05-31T04:49:25Z"
+      },
+      {
+        "id": 14027,
+        "recipientId": 81115,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/400/200/200",
+        "relationship": "가족",
+        "content": "이병헌님의 메세지 내용 48",
+        "font": "Noto Sans",
+        "createdAt": "2023-09-18T14:09:01Z"
+      },
+      {
+        "id": 44822,
+        "recipientId": 81115,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/72/200/200",
+        "relationship": "동료",
+        "content": "송혜교님의 메세지 내용 69",
+        "font": "Roboto",
+        "createdAt": "2023-01-23T11:25:20Z"
+      }
+    ],
+    "reactionCount": 93,
+    "topReactions": [
+      {
+        "id": 89132,
+        "emoji": "🎉",
+        "count": 18
+      }
+    ]
+  },
+  {
+    "id": 10154,
+    "name": "전지현",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/10154/600/400",
+    "createdAt": "2023-06-12T22:34:51Z",
+    "messageCount": 6,
+    "recentMessages": [
+      {
+        "id": 60424,
+        "recipientId": 10154,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/403/200/200",
+        "relationship": "지인",
+        "content": "박서준님의 메세지 내용 75",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-12-05T21:36:47Z"
+      },
+      {
+        "id": 95935,
+        "recipientId": 10154,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/400/200/200",
+        "relationship": "친구",
+        "content": "한지민님의 메세지 내용 12",
+        "font": "Pretendard",
+        "createdAt": "2023-04-29T17:49:22Z"
+      },
+      {
+        "id": 21882,
+        "recipientId": 10154,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/384/200/200",
+        "relationship": "가족",
+        "content": "최민수님의 메세지 내용 22",
+        "font": "Noto Sans",
+        "createdAt": "2023-07-08T02:01:05Z"
+      }
+    ],
+    "reactionCount": 93,
+    "topReactions": [
+      {
+        "id": 21925,
+        "emoji": "😀",
+        "count": 4
+      }
+    ]
+  },
+  {
+    "id": 13587,
+    "name": "송혜교",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/13587/600/400",
+    "createdAt": "2023-12-29T20:05:55Z",
+    "messageCount": 3,
+    "recentMessages": [
+      {
+        "id": 27566,
+        "recipientId": 13587,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/368/200/200",
+        "relationship": "지인",
+        "content": "박서준님의 메세지 내용 6",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-10-20T11:16:20Z"
+      },
+      {
+        "id": 2019,
+        "recipientId": 13587,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/478/200/200",
+        "relationship": "동료",
+        "content": "송혜교님의 메세지 내용 26",
+        "font": "Noto Sans",
+        "createdAt": "2023-08-01T07:45:11Z"
+      },
+      {
+        "id": 54173,
+        "recipientId": 13587,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/284/200/200",
+        "relationship": "동료",
+        "content": "한지민님의 메세지 내용 41",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-02-02T17:16:38Z"
+      }
+    ],
+    "reactionCount": 10,
+    "topReactions": [
+      {
+        "id": 71407,
+        "emoji": "😁",
+        "count": 11
+      }
+    ]
+  },
+  {
+    "id": 1309,
+    "name": "김하은",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/1309/600/400",
+    "createdAt": "2023-08-30T03:31:58Z",
+    "messageCount": 9,
+    "recentMessages": [
+      {
+        "id": 76069,
+        "recipientId": 1309,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/59/200/200",
+        "relationship": "친구",
+        "content": "전지현님의 메세지 내용 64",
+        "font": "Pretendard",
+        "createdAt": "2023-08-15T14:13:51Z"
+      },
+      {
+        "id": 57299,
+        "recipientId": 1309,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/23/200/200",
+        "relationship": "가족",
+        "content": "전지현님의 메세지 내용 2",
+        "font": "Roboto",
+        "createdAt": "2023-09-25T10:40:09Z"
+      },
+      {
+        "id": 83909,
+        "recipientId": 1309,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/355/200/200",
+        "relationship": "가족",
+        "content": "현빈님의 메세지 내용 53",
+        "font": "Roboto",
+        "createdAt": "2023-05-08T18:45:38Z"
+      }
+    ],
+    "reactionCount": 30,
+    "topReactions": [
+      {
+        "id": 45061,
+        "emoji": "❤️",
+        "count": 20
+      },
+      {
+        "id": 40818,
+        "emoji": "❤️",
+        "count": 20
+      },
+      {
+        "id": 86400,
+        "emoji": "🥹",
+        "count": 3
+      },
+      {
+        "id": 90349,
+        "emoji": "🥹",
+        "count": 1
+      },
+      {
+        "id": 307,
+        "emoji": "😁",
+        "count": 9
+      }
+    ]
+  },
+  {
+    "id": 60,
+    "name": "현빈",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/60/600/400",
+    "createdAt": "2023-07-09T12:28:11Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 74309,
+        "recipientId": 60,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/65/200/200",
+        "relationship": "친구",
+        "content": "정우성님의 메세지 내용 96",
+        "font": "Noto Sans",
+        "createdAt": "2023-08-25T21:47:15Z"
+      },
+      {
+        "id": 94122,
+        "recipientId": 60,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/141/200/200",
+        "relationship": "친구",
+        "content": "한지민님의 메세지 내용 57",
+        "font": "Roboto",
+        "createdAt": "2023-09-05T23:47:09Z"
+      },
+      {
+        "id": 16314,
+        "recipientId": 60,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/345/200/200",
+        "relationship": "동료",
+        "content": "이병헌님의 메세지 내용 52",
+        "font": "Roboto",
+        "createdAt": "2023-03-07T04:55:33Z"
+      }
+    ],
+    "reactionCount": 50,
+    "topReactions": [
+      {
+        "id": 58906,
+        "emoji": "😀",
+        "count": 1
+      },
+      {
+        "id": 50471,
+        "emoji": "🎉",
+        "count": 7
+      }
+    ]
+  },
+  {
+    "id": 66554,
+    "name": "현빈",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/66554/600/400",
+    "createdAt": "2023-02-08T20:35:33Z",
+    "messageCount": 6,
+    "recentMessages": [
+      {
+        "id": 66047,
+        "recipientId": 66554,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/500/200/200",
+        "relationship": "지인",
+        "content": "최민수님의 메세지 내용 92",
+        "font": "Pretendard",
+        "createdAt": "2023-04-08T22:14:02Z"
+      },
+      {
+        "id": 81467,
+        "recipientId": 66554,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/487/200/200",
+        "relationship": "가족",
+        "content": "이병헌님의 메세지 내용 17",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-03-16T05:19:39Z"
+      },
+      {
+        "id": 63910,
+        "recipientId": 66554,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/348/200/200",
+        "relationship": "지인",
+        "content": "정우성님의 메세지 내용 66",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-08-22T16:52:48Z"
+      }
+    ],
+    "reactionCount": 78,
+    "topReactions": [
+      {
+        "id": 11998,
+        "emoji": "😀",
+        "count": 1
+      },
+      {
+        "id": 43630,
+        "emoji": "❤️",
+        "count": 5
+      },
+      {
+        "id": 4909,
+        "emoji": "🥹",
+        "count": 10
+      },
+      {
+        "id": 15023,
+        "emoji": "😁",
+        "count": 4
+      }
+    ]
+  },
+  {
+    "id": 50312,
+    "name": "현빈",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2023-02-27T12:29:12Z",
+    "messageCount": 10,
+    "recentMessages": [
+      {
+        "id": 33254,
+        "recipientId": 50312,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/460/200/200",
+        "relationship": "동료",
+        "content": "김하은님의 메세지 내용 22",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-04-14T03:51:21Z"
+      },
+      {
+        "id": 19330,
+        "recipientId": 50312,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/435/200/200",
+        "relationship": "가족",
+        "content": "전지현님의 메세지 내용 14",
+        "font": "Pretendard",
+        "createdAt": "2023-03-07T02:10:58Z"
+      },
+      {
+        "id": 15393,
+        "recipientId": 50312,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/59/200/200",
+        "relationship": "동료",
+        "content": "박서준님의 메세지 내용 12",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-01-11T22:57:14Z"
+      }
+    ],
+    "reactionCount": 97,
+    "topReactions": [
+      {
+        "id": 73411,
+        "emoji": "❤️",
+        "count": 14
+      },
+      {
+        "id": 26879,
+        "emoji": "🥹",
+        "count": 9
+      }
+    ]
+  },
+  {
+    "id": 33720,
+    "name": "송혜교",
+    "backgroundColor": "green",
+    "backgroundImageURL": null,
+    "createdAt": "2023-07-18T19:49:30Z",
+    "messageCount": 1,
+    "recentMessages": [
+      {
+        "id": 81755,
+        "recipientId": 33720,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/338/200/200",
+        "relationship": "친구",
+        "content": "최민수님의 메세지 내용 25",
+        "font": "Nanum Gothic",
+        "createdAt": "2024-01-25T12:37:51Z"
+      }
+    ],
+    "reactionCount": 41,
+    "topReactions": [
+      {
+        "id": 69423,
+        "emoji": "🥹",
+        "count": 19
+      },
+      {
+        "id": 37533,
+        "emoji": "🎉",
+        "count": 10
+      },
+      {
+        "id": 73552,
+        "emoji": "😁",
+        "count": 5
+      },
+      {
+        "id": 58186,
+        "emoji": "🥹",
+        "count": 8
+      },
+      {
+        "id": 26741,
+        "emoji": "😁",
+        "count": 18
+      },
+      {
+        "id": 8330,
+        "emoji": "❤️",
+        "count": 6
+      }
+    ]
+  },
+  {
+    "id": 89805,
+    "name": "전지현",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/89805/600/400",
+    "createdAt": "2023-08-19T06:07:50Z",
+    "messageCount": 2,
+    "recentMessages": [
+      {
+        "id": 7586,
+        "recipientId": 89805,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/442/200/200",
+        "relationship": "가족",
+        "content": "이영준님의 메세지 내용 63",
+        "font": "Pretendard",
+        "createdAt": "2023-01-04T13:08:22Z"
+      },
+      {
+        "id": 86570,
+        "recipientId": 89805,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/258/200/200",
+        "relationship": "동료",
+        "content": "현빈님의 메세지 내용 10",
+        "font": "Roboto",
+        "createdAt": "2023-08-21T15:47:23Z"
+      }
+    ],
+    "reactionCount": 35,
+    "topReactions": [
+      {
+        "id": 44310,
+        "emoji": "🥹",
+        "count": 4
+      },
+      {
+        "id": 10011,
+        "emoji": "❤️",
+        "count": 6
+      },
+      {
+        "id": 8641,
+        "emoji": "🥹",
+        "count": 4
+      }
+    ]
+  },
+  {
+    "id": 31459,
+    "name": "최민수",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/31459/600/400",
+    "createdAt": "2023-06-23T11:39:38Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 98356,
+        "recipientId": 31459,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/139/200/200",
+        "relationship": "친구",
+        "content": "정우성님의 메세지 내용 14",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-03-11T09:10:45Z"
+      },
+      {
+        "id": 37388,
+        "recipientId": 31459,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/355/200/200",
+        "relationship": "친구",
+        "content": "박서준님의 메세지 내용 57",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-02-22T09:31:25Z"
+      },
+      {
+        "id": 19962,
+        "recipientId": 31459,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/80/200/200",
+        "relationship": "동료",
+        "content": "이병헌님의 메세지 내용 11",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-11-26T04:31:20Z"
+      }
+    ],
+    "reactionCount": 21,
+    "topReactions": [
+      {
+        "id": 4005,
+        "emoji": "😀",
+        "count": 7
+      }
+    ]
+  },
+  {
+    "id": 98283,
+    "name": "최민수",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/98283/600/400",
+    "createdAt": "2023-07-15T05:18:24Z",
+    "messageCount": 6,
+    "recentMessages": [
+      {
+        "id": 30487,
+        "recipientId": 98283,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/228/200/200",
+        "relationship": "동료",
+        "content": "김하은님의 메세지 내용 61",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-12-02T07:23:57Z"
+      },
+      {
+        "id": 46260,
+        "recipientId": 98283,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/362/200/200",
+        "relationship": "지인",
+        "content": "최민수님의 메세지 내용 2",
+        "font": "Roboto",
+        "createdAt": "2024-01-05T15:10:35Z"
+      },
+      {
+        "id": 21359,
+        "recipientId": 98283,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/309/200/200",
+        "relationship": "지인",
+        "content": "김하은님의 메세지 내용 25",
+        "font": "Roboto",
+        "createdAt": "2023-12-23T15:06:51Z"
+      }
+    ],
+    "reactionCount": 5,
+    "topReactions": [
+      {
+        "id": 5588,
+        "emoji": "❤️",
+        "count": 5
+      },
+      {
+        "id": 98400,
+        "emoji": "🥹",
+        "count": 13
+      },
+      {
+        "id": 5484,
+        "emoji": "❤️",
+        "count": 16
+      },
+      {
+        "id": 40058,
+        "emoji": "🎉",
+        "count": 2
+      },
+      {
+        "id": 51056,
+        "emoji": "👍",
+        "count": 14
+      },
+      {
+        "id": 31995,
+        "emoji": "🎉",
+        "count": 12
+      }
+    ]
+  },
+  {
+    "id": 37766,
+    "name": "현빈",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-02-25T16:44:40Z",
+    "messageCount": 5,
+    "recentMessages": [
+      {
+        "id": 12013,
+        "recipientId": 37766,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/343/200/200",
+        "relationship": "지인",
+        "content": "이영준님의 메세지 내용 33",
+        "font": "Nanum Gothic",
+        "createdAt": "2024-01-27T17:03:16Z"
+      },
+      {
+        "id": 63267,
+        "recipientId": 37766,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/318/200/200",
+        "relationship": "가족",
+        "content": "현빈님의 메세지 내용 37",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-10-30T06:35:37Z"
+      },
+      {
+        "id": 32221,
+        "recipientId": 37766,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/254/200/200",
+        "relationship": "지인",
+        "content": "김하은님의 메세지 내용 51",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-05-22T08:02:04Z"
+      }
+    ],
+    "reactionCount": 6,
+    "topReactions": [
+      {
+        "id": 51742,
+        "emoji": "🥹",
+        "count": 6
+      },
+      {
+        "id": 48690,
+        "emoji": "🎉",
+        "count": 2
+      },
+      {
+        "id": 50705,
+        "emoji": "😀",
+        "count": 14
+      },
+      {
+        "id": 8991,
+        "emoji": "😀",
+        "count": 10
+      },
+      {
+        "id": 12174,
+        "emoji": "🥹",
+        "count": 9
+      },
+      {
+        "id": 10137,
+        "emoji": "😀",
+        "count": 10
+      }
+    ]
+  },
+  {
+    "id": 55770,
+    "name": "김하은",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/55770/600/400",
+    "createdAt": "2023-08-08T18:49:27Z",
+    "messageCount": 10,
+    "recentMessages": [
+      {
+        "id": 98997,
+        "recipientId": 55770,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/310/200/200",
+        "relationship": "지인",
+        "content": "정우성님의 메세지 내용 76",
+        "font": "Pretendard",
+        "createdAt": "2023-12-28T10:22:01Z"
+      },
+      {
+        "id": 52895,
+        "recipientId": 55770,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/192/200/200",
+        "relationship": "가족",
+        "content": "이영준님의 메세지 내용 58",
+        "font": "Pretendard",
+        "createdAt": "2024-01-11T11:32:14Z"
+      },
+      {
+        "id": 45725,
+        "recipientId": 55770,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/188/200/200",
+        "relationship": "친구",
+        "content": "이영준님의 메세지 내용 29",
+        "font": "Roboto",
+        "createdAt": "2023-07-13T20:07:35Z"
+      }
+    ],
+    "reactionCount": 90,
+    "topReactions": [
+      {
+        "id": 16362,
+        "emoji": "😁",
+        "count": 14
+      },
+      {
+        "id": 6576,
+        "emoji": "🥹",
+        "count": 14
+      },
+      {
+        "id": 78222,
+        "emoji": "🎉",
+        "count": 1
+      },
+      {
+        "id": 62128,
+        "emoji": "😁",
+        "count": 18
+      }
+    ]
+  },
+  {
+    "id": 41885,
+    "name": "송혜교",
+    "backgroundColor": "blue",
+    "backgroundImageURL": null,
+    "createdAt": "2023-09-29T17:30:26Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 3980,
+        "recipientId": 41885,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/124/200/200",
+        "relationship": "지인",
+        "content": "전지현님의 메세지 내용 53",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-02-11T20:10:45Z"
+      },
+      {
+        "id": 24156,
+        "recipientId": 41885,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/360/200/200",
+        "relationship": "친구",
+        "content": "이병헌님의 메세지 내용 14",
+        "font": "Noto Sans",
+        "createdAt": "2023-07-13T21:35:18Z"
+      },
+      {
+        "id": 88059,
+        "recipientId": 41885,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/182/200/200",
+        "relationship": "지인",
+        "content": "현빈님의 메세지 내용 33",
+        "font": "Pretendard",
+        "createdAt": "2023-08-04T15:40:39Z"
+      }
+    ],
+    "reactionCount": 9,
+    "topReactions": [
+      {
+        "id": 31604,
+        "emoji": "😀",
+        "count": 15
+      },
+      {
+        "id": 7967,
+        "emoji": "😁",
+        "count": 2
+      },
+      {
+        "id": 52857,
+        "emoji": "🥹",
+        "count": 14
+      },
+      {
+        "id": 52766,
+        "emoji": "😀",
+        "count": 13
+      }
+    ]
+  },
+  {
+    "id": 11840,
+    "name": "송혜교",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/11840/600/400",
+    "createdAt": "2024-01-31T05:35:10Z",
+    "messageCount": 5,
+    "recentMessages": [
+      {
+        "id": 15003,
+        "recipientId": 11840,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/98/200/200",
+        "relationship": "지인",
+        "content": "김하은님의 메세지 내용 76",
+        "font": "Noto Sans",
+        "createdAt": "2023-07-19T06:37:06Z"
+      },
+      {
+        "id": 11159,
+        "recipientId": 11840,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/7/200/200",
+        "relationship": "지인",
+        "content": "김하은님의 메세지 내용 99",
+        "font": "Noto Sans",
+        "createdAt": "2023-02-04T05:57:58Z"
+      },
+      {
+        "id": 11261,
+        "recipientId": 11840,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/444/200/200",
+        "relationship": "동료",
+        "content": "김하은님의 메세지 내용 43",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-03-31T14:51:43Z"
+      }
+    ],
+    "reactionCount": 21,
+    "topReactions": [
+      {
+        "id": 13179,
+        "emoji": "🎉",
+        "count": 3
+      },
+      {
+        "id": 5003,
+        "emoji": "🥹",
+        "count": 1
+      },
+      {
+        "id": 37584,
+        "emoji": "🥹",
+        "count": 4
+      },
+      {
+        "id": 63440,
+        "emoji": "🎉",
+        "count": 4
+      }
+    ]
+  },
+  {
+    "id": 84895,
+    "name": "한지민",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/84895/600/400",
+    "createdAt": "2023-04-23T06:14:19Z",
+    "messageCount": 1,
+    "recentMessages": [
+      {
+        "id": 94574,
+        "recipientId": 84895,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/3/200/200",
+        "relationship": "지인",
+        "content": "이영준님의 메세지 내용 13",
+        "font": "Noto Sans",
+        "createdAt": "2023-01-18T07:30:08Z"
+      }
+    ],
+    "reactionCount": 37,
+    "topReactions": [
+      {
+        "id": 1985,
+        "emoji": "👍",
+        "count": 9
+      },
+      {
+        "id": 65556,
+        "emoji": "❤️",
+        "count": 7
+      },
+      {
+        "id": 96682,
+        "emoji": "😁",
+        "count": 9
+      },
+      {
+        "id": 49044,
+        "emoji": "🎉",
+        "count": 13
+      },
+      {
+        "id": 76158,
+        "emoji": "❤️",
+        "count": 7
+      }
+    ]
+  },
+  {
+    "id": 74955,
+    "name": "현빈",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/74955/600/400",
+    "createdAt": "2023-03-01T11:31:01Z",
+    "messageCount": 1,
+    "recentMessages": [
+      {
+        "id": 27531,
+        "recipientId": 74955,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/466/200/200",
+        "relationship": "친구",
+        "content": "한지민님의 메세지 내용 17",
+        "font": "Noto Sans",
+        "createdAt": "2023-09-22T15:59:45Z"
+      }
+    ],
+    "reactionCount": 33,
+    "topReactions": [
+      {
+        "id": 38198,
+        "emoji": "😁",
+        "count": 5
+      },
+      {
+        "id": 75156,
+        "emoji": "🥹",
+        "count": 11
+      },
+      {
+        "id": 85523,
+        "emoji": "🥹",
+        "count": 4
+      },
+      {
+        "id": 68198,
+        "emoji": "🎉",
+        "count": 5
+      },
+      {
+        "id": 91,
+        "emoji": "😁",
+        "count": 9
+      },
+      {
+        "id": 249,
+        "emoji": "😀",
+        "count": 4
+      }
+    ]
+  },
+  {
+    "id": 91125,
+    "name": "이영준",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/91125/600/400",
+    "createdAt": "2023-01-25T16:51:01Z",
+    "messageCount": 2,
+    "recentMessages": [
+      {
+        "id": 81022,
+        "recipientId": 91125,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/157/200/200",
+        "relationship": "친구",
+        "content": "이영준님의 메세지 내용 90",
+        "font": "Noto Sans",
+        "createdAt": "2023-09-19T23:00:03Z"
+      },
+      {
+        "id": 51294,
+        "recipientId": 91125,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/284/200/200",
+        "relationship": "지인",
+        "content": "최민수님의 메세지 내용 26",
+        "font": "Noto Sans",
+        "createdAt": "2024-01-29T11:52:15Z"
+      }
+    ],
+    "reactionCount": 28,
+    "topReactions": [
+      {
+        "id": 13204,
+        "emoji": "😀",
+        "count": 13
+      },
+      {
+        "id": 16155,
+        "emoji": "🎉",
+        "count": 19
+      },
+      {
+        "id": 68608,
+        "emoji": "😀",
+        "count": 18
+      },
+      {
+        "id": 78848,
+        "emoji": "😀",
+        "count": 18
+      },
+      {
+        "id": 4799,
+        "emoji": "👍",
+        "count": 12
+      }
+    ]
+  },
+  {
+    "id": 57687,
+    "name": "한지민",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/57687/600/400",
+    "createdAt": "2023-11-07T02:40:34Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 12712,
+        "recipientId": 57687,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/148/200/200",
+        "relationship": "가족",
+        "content": "송혜교님의 메세지 내용 27",
+        "font": "Roboto",
+        "createdAt": "2023-11-26T12:14:09Z"
+      },
+      {
+        "id": 28850,
+        "recipientId": 57687,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/109/200/200",
+        "relationship": "친구",
+        "content": "현빈님의 메세지 내용 79",
+        "font": "Roboto",
+        "createdAt": "2023-11-16T14:25:15Z"
+      },
+      {
+        "id": 91115,
+        "recipientId": 57687,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/335/200/200",
+        "relationship": "지인",
+        "content": "현빈님의 메세지 내용 88",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-12-06T16:17:35Z"
+      }
+    ],
+    "reactionCount": 100,
+    "topReactions": [
+      {
+        "id": 72646,
+        "emoji": "❤️",
+        "count": 5
+      }
+    ]
+  },
+  {
+    "id": 52082,
+    "name": "박서준",
+    "backgroundColor": "green",
+    "backgroundImageURL": null,
+    "createdAt": "2023-12-05T11:50:03Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 34872,
+        "recipientId": 52082,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/314/200/200",
+        "relationship": "지인",
+        "content": "한지민님의 메세지 내용 79",
+        "font": "Pretendard",
+        "createdAt": "2023-06-29T10:39:24Z"
+      },
+      {
+        "id": 11518,
+        "recipientId": 52082,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/337/200/200",
+        "relationship": "지인",
+        "content": "현빈님의 메세지 내용 82",
+        "font": "Pretendard",
+        "createdAt": "2023-01-14T11:17:39Z"
+      },
+      {
+        "id": 34015,
+        "recipientId": 52082,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/162/200/200",
+        "relationship": "가족",
+        "content": "최민수님의 메세지 내용 42",
+        "font": "Roboto",
+        "createdAt": "2023-09-22T11:36:35Z"
+      }
+    ],
+    "reactionCount": 72,
+    "topReactions": [
+      {
+        "id": 37949,
+        "emoji": "❤️",
+        "count": 10
+      },
+      {
+        "id": 46408,
+        "emoji": "😀",
+        "count": 1
+      }
+    ]
+  },
+  {
+    "id": 39017,
+    "name": "정우성",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/39017/600/400",
+    "createdAt": "2024-01-28T05:11:05Z",
+    "messageCount": 2,
+    "recentMessages": [
+      {
+        "id": 45901,
+        "recipientId": 39017,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/221/200/200",
+        "relationship": "친구",
+        "content": "정우성님의 메세지 내용 37",
+        "font": "Roboto",
+        "createdAt": "2023-04-24T18:45:37Z"
+      },
+      {
+        "id": 86974,
+        "recipientId": 39017,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/96/200/200",
+        "relationship": "가족",
+        "content": "한지민님의 메세지 내용 97",
+        "font": "Nanum Gothic",
+        "createdAt": "2024-01-06T07:57:03Z"
+      }
+    ],
+    "reactionCount": 100,
+    "topReactions": [
+      {
+        "id": 51363,
+        "emoji": "😀",
+        "count": 9
+      }
+    ]
+  },
+  {
+    "id": 46642,
+    "name": "전지현",
+    "backgroundColor": "green",
+    "backgroundImageURL": null,
+    "createdAt": "2024-01-27T23:23:34Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 86564,
+        "recipientId": 46642,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/36/200/200",
+        "relationship": "지인",
+        "content": "이병헌님의 메세지 내용 78",
+        "font": "Noto Sans",
+        "createdAt": "2023-09-23T23:48:17Z"
+      },
+      {
+        "id": 46880,
+        "recipientId": 46642,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/453/200/200",
+        "relationship": "가족",
+        "content": "이병헌님의 메세지 내용 92",
+        "font": "Noto Sans",
+        "createdAt": "2023-06-07T09:44:08Z"
+      },
+      {
+        "id": 79147,
+        "recipientId": 46642,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/425/200/200",
+        "relationship": "지인",
+        "content": "최민수님의 메세지 내용 45",
+        "font": "Noto Sans",
+        "createdAt": "2023-07-14T00:41:05Z"
+      }
+    ],
+    "reactionCount": 24,
+    "topReactions": [
+      {
+        "id": 50493,
+        "emoji": "🥹",
+        "count": 10
+      },
+      {
+        "id": 14174,
+        "emoji": "❤️",
+        "count": 7
+      },
+      {
+        "id": 8164,
+        "emoji": "😀",
+        "count": 14
+      },
+      {
+        "id": 59391,
+        "emoji": "😁",
+        "count": 12
+      },
+      {
+        "id": 503,
+        "emoji": "❤️",
+        "count": 14
+      },
+      {
+        "id": 96571,
+        "emoji": "❤️",
+        "count": 7
+      }
+    ]
+  },
+  {
+    "id": 27652,
+    "name": "송혜교",
+    "backgroundColor": "green",
+    "backgroundImageURL": null,
+    "createdAt": "2023-01-26T14:15:49Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 36699,
+        "recipientId": 27652,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/323/200/200",
+        "relationship": "가족",
+        "content": "최민수님의 메세지 내용 56",
+        "font": "Noto Sans",
+        "createdAt": "2023-08-24T00:21:48Z"
+      },
+      {
+        "id": 75023,
+        "recipientId": 27652,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/442/200/200",
+        "relationship": "가족",
+        "content": "김하은님의 메세지 내용 56",
+        "font": "Roboto",
+        "createdAt": "2023-02-11T12:51:39Z"
+      },
+      {
+        "id": 31848,
+        "recipientId": 27652,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/273/200/200",
+        "relationship": "친구",
+        "content": "최민수님의 메세지 내용 84",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-12-04T00:48:02Z"
+      }
+    ],
+    "reactionCount": 93,
+    "topReactions": [
+      {
+        "id": 90352,
+        "emoji": "😁",
+        "count": 1
+      }
+    ]
+  },
+  {
+    "id": 93469,
+    "name": "이병헌",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/93469/600/400",
+    "createdAt": "2023-08-05T08:37:01Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 13315,
+        "recipientId": 93469,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/407/200/200",
+        "relationship": "지인",
+        "content": "한지민님의 메세지 내용 15",
+        "font": "Noto Sans",
+        "createdAt": "2023-07-27T04:45:59Z"
+      },
+      {
+        "id": 29127,
+        "recipientId": 93469,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/206/200/200",
+        "relationship": "동료",
+        "content": "한지민님의 메세지 내용 61",
+        "font": "Pretendard",
+        "createdAt": "2023-12-08T16:05:47Z"
+      },
+      {
+        "id": 40814,
+        "recipientId": 93469,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/176/200/200",
+        "relationship": "동료",
+        "content": "박서준님의 메세지 내용 72",
+        "font": "Noto Sans",
+        "createdAt": "2023-04-25T05:08:02Z"
+      }
+    ],
+    "reactionCount": 84,
+    "topReactions": [
+      {
+        "id": 89622,
+        "emoji": "🎉",
+        "count": 13
+      },
+      {
+        "id": 63069,
+        "emoji": "🎉",
+        "count": 4
+      },
+      {
+        "id": 24110,
+        "emoji": "😀",
+        "count": 4
+      },
+      {
+        "id": 67263,
+        "emoji": "👍",
+        "count": 12
+      }
+    ]
+  },
+  {
+    "id": 45950,
+    "name": "이병헌",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/45950/600/400",
+    "createdAt": "2023-04-24T21:39:46Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 25018,
+        "recipientId": 45950,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/422/200/200",
+        "relationship": "가족",
+        "content": "한지민님의 메세지 내용 66",
+        "font": "Noto Sans",
+        "createdAt": "2024-02-01T13:50:42Z"
+      },
+      {
+        "id": 24874,
+        "recipientId": 45950,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/55/200/200",
+        "relationship": "동료",
+        "content": "김하은님의 메세지 내용 32",
+        "font": "Pretendard",
+        "createdAt": "2023-09-13T01:51:09Z"
+      },
+      {
+        "id": 27922,
+        "recipientId": 45950,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/167/200/200",
+        "relationship": "동료",
+        "content": "송혜교님의 메세지 내용 76",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-01-10T17:10:48Z"
+      }
+    ],
+    "reactionCount": 45,
+    "topReactions": [
+      {
+        "id": 39540,
+        "emoji": "🎉",
+        "count": 13
+      }
+    ]
+  },
+  {
+    "id": 92578,
+    "name": "현빈",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-06-01T11:14:03Z",
+    "messageCount": 5,
+    "recentMessages": [
+      {
+        "id": 41959,
+        "recipientId": 92578,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/160/200/200",
+        "relationship": "지인",
+        "content": "전지현님의 메세지 내용 4",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-08-16T02:51:30Z"
+      },
+      {
+        "id": 1530,
+        "recipientId": 92578,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/438/200/200",
+        "relationship": "동료",
+        "content": "현빈님의 메세지 내용 59",
+        "font": "Roboto",
+        "createdAt": "2023-03-12T23:02:00Z"
+      },
+      {
+        "id": 65787,
+        "recipientId": 92578,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/184/200/200",
+        "relationship": "가족",
+        "content": "이영준님의 메세지 내용 88",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-05-13T21:14:10Z"
+      }
+    ],
+    "reactionCount": 84,
+    "topReactions": [
+      {
+        "id": 12098,
+        "emoji": "👍",
+        "count": 9
+      },
+      {
+        "id": 54057,
+        "emoji": "😀",
+        "count": 9
+      },
+      {
+        "id": 45620,
+        "emoji": "👍",
+        "count": 3
+      }
+    ]
+  },
+  {
+    "id": 987,
+    "name": "이영준",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/987/600/400",
+    "createdAt": "2023-08-21T17:47:59Z",
+    "messageCount": 3,
+    "recentMessages": [
+      {
+        "id": 67695,
+        "recipientId": 987,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/108/200/200",
+        "relationship": "동료",
+        "content": "현빈님의 메세지 내용 28",
+        "font": "Noto Sans",
+        "createdAt": "2023-06-19T07:08:12Z"
+      },
+      {
+        "id": 78843,
+        "recipientId": 987,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/129/200/200",
+        "relationship": "동료",
+        "content": "이영준님의 메세지 내용 19",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-09-22T16:14:47Z"
+      },
+      {
+        "id": 1843,
+        "recipientId": 987,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/495/200/200",
+        "relationship": "친구",
+        "content": "정우성님의 메세지 내용 70",
+        "font": "Roboto",
+        "createdAt": "2023-07-04T06:42:44Z"
+      }
+    ],
+    "reactionCount": 72,
+    "topReactions": [
+      {
+        "id": 76463,
+        "emoji": "😁",
+        "count": 15
+      },
+      {
+        "id": 25167,
+        "emoji": "🎉",
+        "count": 19
+      },
+      {
+        "id": 5479,
+        "emoji": "🥹",
+        "count": 2
+      },
+      {
+        "id": 92981,
+        "emoji": "😀",
+        "count": 17
+      },
+      {
+        "id": 85208,
+        "emoji": "😁",
+        "count": 10
+      },
+      {
+        "id": 61758,
+        "emoji": "👍",
+        "count": 8
+      }
+    ]
+  },
+  {
+    "id": 99277,
+    "name": "한지민",
+    "backgroundColor": "blue",
+    "backgroundImageURL": null,
+    "createdAt": "2023-03-08T21:42:42Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 18287,
+        "recipientId": 99277,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/355/200/200",
+        "relationship": "지인",
+        "content": "전지현님의 메세지 내용 63",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-02-21T08:53:40Z"
+      },
+      {
+        "id": 40708,
+        "recipientId": 99277,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/255/200/200",
+        "relationship": "동료",
+        "content": "정우성님의 메세지 내용 48",
+        "font": "Noto Sans",
+        "createdAt": "2023-01-25T02:33:40Z"
+      },
+      {
+        "id": 96884,
+        "recipientId": 99277,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/362/200/200",
+        "relationship": "가족",
+        "content": "정우성님의 메세지 내용 31",
+        "font": "Nanum Gothic",
+        "createdAt": "2024-02-01T10:45:29Z"
+      }
+    ],
+    "reactionCount": 70,
+    "topReactions": [
+      {
+        "id": 11095,
+        "emoji": "😁",
+        "count": 1
+      },
+      {
+        "id": 76832,
+        "emoji": "👍",
+        "count": 1
+      },
+      {
+        "id": 65012,
+        "emoji": "🥹",
+        "count": 7
+      },
+      {
+        "id": 65074,
+        "emoji": "🎉",
+        "count": 2
+      }
+    ]
+  },
+  {
+    "id": 47918,
+    "name": "최민수",
+    "backgroundColor": "green",
+    "backgroundImageURL": null,
+    "createdAt": "2024-01-06T11:36:10Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 39350,
+        "recipientId": 47918,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/404/200/200",
+        "relationship": "친구",
+        "content": "정우성님의 메세지 내용 80",
+        "font": "Pretendard",
+        "createdAt": "2023-07-04T05:30:48Z"
+      },
+      {
+        "id": 90854,
+        "recipientId": 47918,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/278/200/200",
+        "relationship": "동료",
+        "content": "최민수님의 메세지 내용 4",
+        "font": "Pretendard",
+        "createdAt": "2024-01-27T06:10:05Z"
+      },
+      {
+        "id": 98946,
+        "recipientId": 47918,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/199/200/200",
+        "relationship": "지인",
+        "content": "김하은님의 메세지 내용 47",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-08-20T22:18:43Z"
+      }
+    ],
+    "reactionCount": 34,
+    "topReactions": [
+      {
+        "id": 17825,
+        "emoji": "🎉",
+        "count": 10
+      },
+      {
+        "id": 85431,
+        "emoji": "❤️",
+        "count": 1
+      }
+    ]
+  },
+  {
+    "id": 60144,
+    "name": "송혜교",
+    "backgroundColor": "green",
+    "backgroundImageURL": null,
+    "createdAt": "2023-03-27T21:09:40Z",
+    "messageCount": 3,
+    "recentMessages": [
+      {
+        "id": 48501,
+        "recipientId": 60144,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/499/200/200",
+        "relationship": "지인",
+        "content": "박서준님의 메세지 내용 90",
+        "font": "Roboto",
+        "createdAt": "2023-08-30T23:42:40Z"
+      },
+      {
+        "id": 32650,
+        "recipientId": 60144,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/196/200/200",
+        "relationship": "지인",
+        "content": "전지현님의 메세지 내용 16",
+        "font": "Roboto",
+        "createdAt": "2023-03-07T02:31:44Z"
+      },
+      {
+        "id": 90329,
+        "recipientId": 60144,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/500/200/200",
+        "relationship": "친구",
+        "content": "김하은님의 메세지 내용 70",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-11-02T05:53:11Z"
+      }
+    ],
+    "reactionCount": 4,
+    "topReactions": [
+      {
+        "id": 50561,
+        "emoji": "❤️",
+        "count": 15
+      },
+      {
+        "id": 80082,
+        "emoji": "🎉",
+        "count": 18
+      }
+    ]
+  },
+  {
+    "id": 53261,
+    "name": "송혜교",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/53261/600/400",
+    "createdAt": "2023-03-11T22:52:07Z",
+    "messageCount": 9,
+    "recentMessages": [
+      {
+        "id": 16001,
+        "recipientId": 53261,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/161/200/200",
+        "relationship": "지인",
+        "content": "현빈님의 메세지 내용 31",
+        "font": "Pretendard",
+        "createdAt": "2023-03-14T11:20:15Z"
+      },
+      {
+        "id": 67474,
+        "recipientId": 53261,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/221/200/200",
+        "relationship": "지인",
+        "content": "송혜교님의 메세지 내용 58",
+        "font": "Roboto",
+        "createdAt": "2023-09-04T17:56:53Z"
+      },
+      {
+        "id": 88691,
+        "recipientId": 53261,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/197/200/200",
+        "relationship": "지인",
+        "content": "최민수님의 메세지 내용 49",
+        "font": "Pretendard",
+        "createdAt": "2023-07-18T12:09:53Z"
+      }
+    ],
+    "reactionCount": 41,
+    "topReactions": [
+      {
+        "id": 26308,
+        "emoji": "🥹",
+        "count": 6
+      },
+      {
+        "id": 63793,
+        "emoji": "👍",
+        "count": 11
+      },
+      {
+        "id": 52541,
+        "emoji": "🎉",
+        "count": 4
+      },
+      {
+        "id": 83299,
+        "emoji": "😀",
+        "count": 9
+      },
+      {
+        "id": 85136,
+        "emoji": "🥹",
+        "count": 7
+      },
+      {
+        "id": 889,
+        "emoji": "👍",
+        "count": 7
+      }
+    ]
+  },
+  {
+    "id": 74042,
+    "name": "이영준",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/74042/600/400",
+    "createdAt": "2023-05-01T20:10:57Z",
+    "messageCount": 5,
+    "recentMessages": [
+      {
+        "id": 94808,
+        "recipientId": 74042,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/421/200/200",
+        "relationship": "지인",
+        "content": "김하은님의 메세지 내용 85",
+        "font": "Pretendard",
+        "createdAt": "2024-02-01T06:54:16Z"
+      },
+      {
+        "id": 31960,
+        "recipientId": 74042,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/40/200/200",
+        "relationship": "동료",
+        "content": "최민수님의 메세지 내용 33",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-02-21T23:07:24Z"
+      },
+      {
+        "id": 19007,
+        "recipientId": 74042,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/445/200/200",
+        "relationship": "동료",
+        "content": "박서준님의 메세지 내용 44",
+        "font": "Nanum Gothic",
+        "createdAt": "2024-01-30T06:37:25Z"
+      }
+    ],
+    "reactionCount": 70,
+    "topReactions": [
+      {
+        "id": 40083,
+        "emoji": "👍",
+        "count": 5
+      },
+      {
+        "id": 46868,
+        "emoji": "😀",
+        "count": 4
+      },
+      {
+        "id": 9028,
+        "emoji": "😀",
+        "count": 12
+      },
+      {
+        "id": 33264,
+        "emoji": "😁",
+        "count": 2
+      },
+      {
+        "id": 5936,
+        "emoji": "❤️",
+        "count": 13
+      }
+    ]
+  },
+  {
+    "id": 30047,
+    "name": "한지민",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/30047/600/400",
+    "createdAt": "2023-03-31T10:47:33Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 46241,
+        "recipientId": 30047,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/397/200/200",
+        "relationship": "동료",
+        "content": "이병헌님의 메세지 내용 64",
+        "font": "Roboto",
+        "createdAt": "2023-04-12T04:50:45Z"
+      },
+      {
+        "id": 55605,
+        "recipientId": 30047,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/324/200/200",
+        "relationship": "가족",
+        "content": "전지현님의 메세지 내용 74",
+        "font": "Pretendard",
+        "createdAt": "2023-06-30T12:07:28Z"
+      },
+      {
+        "id": 20989,
+        "recipientId": 30047,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/66/200/200",
+        "relationship": "친구",
+        "content": "정우성님의 메세지 내용 53",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-05-09T11:38:40Z"
+      }
+    ],
+    "reactionCount": 55,
+    "topReactions": [
+      {
+        "id": 35861,
+        "emoji": "👍",
+        "count": 20
+      },
+      {
+        "id": 3537,
+        "emoji": "🎉",
+        "count": 19
+      },
+      {
+        "id": 95822,
+        "emoji": "😀",
+        "count": 11
+      },
+      {
+        "id": 70453,
+        "emoji": "❤️",
+        "count": 10
+      },
+      {
+        "id": 12985,
+        "emoji": "🥹",
+        "count": 18
+      },
+      {
+        "id": 22095,
+        "emoji": "😀",
+        "count": 1
+      }
+    ]
+  },
+  {
+    "id": 96238,
+    "name": "송혜교",
+    "backgroundColor": "green",
+    "backgroundImageURL": null,
+    "createdAt": "2023-11-25T14:18:28Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 67172,
+        "recipientId": 96238,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/384/200/200",
+        "relationship": "친구",
+        "content": "한지민님의 메세지 내용 98",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-12-23T18:55:16Z"
+      },
+      {
+        "id": 14364,
+        "recipientId": 96238,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/113/200/200",
+        "relationship": "가족",
+        "content": "최민수님의 메세지 내용 47",
+        "font": "Noto Sans",
+        "createdAt": "2023-01-18T00:09:07Z"
+      },
+      {
+        "id": 73112,
+        "recipientId": 96238,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/283/200/200",
+        "relationship": "친구",
+        "content": "김하은님의 메세지 내용 10",
+        "font": "Pretendard",
+        "createdAt": "2023-05-27T11:38:52Z"
+      }
+    ],
+    "reactionCount": 96,
+    "topReactions": [
+      {
+        "id": 55075,
+        "emoji": "❤️",
+        "count": 3
+      },
+      {
+        "id": 35577,
+        "emoji": "🎉",
+        "count": 19
+      }
+    ]
+  },
+  {
+    "id": 69917,
+    "name": "현빈",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2023-09-07T23:34:46Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 9243,
+        "recipientId": 69917,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/239/200/200",
+        "relationship": "지인",
+        "content": "전지현님의 메세지 내용 60",
+        "font": "Pretendard",
+        "createdAt": "2023-12-28T01:45:57Z"
+      },
+      {
+        "id": 98887,
+        "recipientId": 69917,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/215/200/200",
+        "relationship": "동료",
+        "content": "전지현님의 메세지 내용 91",
+        "font": "Pretendard",
+        "createdAt": "2023-11-11T18:02:57Z"
+      },
+      {
+        "id": 75801,
+        "recipientId": 69917,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/395/200/200",
+        "relationship": "가족",
+        "content": "전지현님의 메세지 내용 48",
+        "font": "Pretendard",
+        "createdAt": "2023-08-09T15:37:56Z"
+      }
+    ],
+    "reactionCount": 43,
+    "topReactions": [
+      {
+        "id": 5861,
+        "emoji": "🎉",
+        "count": 13
+      },
+      {
+        "id": 44343,
+        "emoji": "🥹",
+        "count": 12
+      },
+      {
+        "id": 43982,
+        "emoji": "🎉",
+        "count": 14
+      },
+      {
+        "id": 4963,
+        "emoji": "🎉",
+        "count": 6
+      }
+    ]
+  },
+  {
+    "id": 5650,
+    "name": "정우성",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/5650/600/400",
+    "createdAt": "2023-01-04T06:22:01Z",
+    "messageCount": 1,
+    "recentMessages": [
+      {
+        "id": 83293,
+        "recipientId": 5650,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/74/200/200",
+        "relationship": "동료",
+        "content": "전지현님의 메세지 내용 2",
+        "font": "Pretendard",
+        "createdAt": "2023-05-23T03:26:03Z"
+      }
+    ],
+    "reactionCount": 71,
+    "topReactions": [
+      {
+        "id": 99348,
+        "emoji": "😁",
+        "count": 10
+      },
+      {
+        "id": 52447,
+        "emoji": "🎉",
+        "count": 19
+      },
+      {
+        "id": 16678,
+        "emoji": "😁",
+        "count": 1
+      }
+    ]
+  },
+  {
+    "id": 97770,
+    "name": "정우성",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-07-20T04:19:16Z",
+    "messageCount": 9,
+    "recentMessages": [
+      {
+        "id": 24717,
+        "recipientId": 97770,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/23/200/200",
+        "relationship": "동료",
+        "content": "김하은님의 메세지 내용 18",
+        "font": "Pretendard",
+        "createdAt": "2023-11-06T09:19:20Z"
+      },
+      {
+        "id": 24145,
+        "recipientId": 97770,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/495/200/200",
+        "relationship": "지인",
+        "content": "이영준님의 메세지 내용 21",
+        "font": "Noto Sans",
+        "createdAt": "2023-10-18T14:16:27Z"
+      },
+      {
+        "id": 223,
+        "recipientId": 97770,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/135/200/200",
+        "relationship": "지인",
+        "content": "정우성님의 메세지 내용 50",
+        "font": "Nanum Gothic",
+        "createdAt": "2024-01-26T11:24:46Z"
+      }
+    ],
+    "reactionCount": 32,
+    "topReactions": [
+      {
+        "id": 20504,
+        "emoji": "🥹",
+        "count": 16
+      },
+      {
+        "id": 54171,
+        "emoji": "😁",
+        "count": 12
+      },
+      {
+        "id": 73446,
+        "emoji": "😁",
+        "count": 6
+      },
+      {
+        "id": 11616,
+        "emoji": "🎉",
+        "count": 7
+      },
+      {
+        "id": 95136,
+        "emoji": "🥹",
+        "count": 5
+      }
+    ]
+  },
+  {
+    "id": 4150,
+    "name": "전지현",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2023-02-04T22:57:07Z",
+    "messageCount": 9,
+    "recentMessages": [
+      {
+        "id": 72918,
+        "recipientId": 4150,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/397/200/200",
+        "relationship": "친구",
+        "content": "현빈님의 메세지 내용 33",
+        "font": "Noto Sans",
+        "createdAt": "2023-08-24T09:46:19Z"
+      },
+      {
+        "id": 84168,
+        "recipientId": 4150,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/409/200/200",
+        "relationship": "동료",
+        "content": "이영준님의 메세지 내용 67",
+        "font": "Noto Sans",
+        "createdAt": "2023-05-15T01:03:21Z"
+      },
+      {
+        "id": 71121,
+        "recipientId": 4150,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/333/200/200",
+        "relationship": "동료",
+        "content": "박서준님의 메세지 내용 81",
+        "font": "Noto Sans",
+        "createdAt": "2023-10-09T10:58:43Z"
+      }
+    ],
+    "reactionCount": 31,
+    "topReactions": [
+      {
+        "id": 57710,
+        "emoji": "😀",
+        "count": 2
+      },
+      {
+        "id": 8909,
+        "emoji": "🥹",
+        "count": 2
+      },
+      {
+        "id": 28098,
+        "emoji": "🥹",
+        "count": 9
+      }
+    ]
+  },
+  {
+    "id": 44091,
+    "name": "이병헌",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/44091/600/400",
+    "createdAt": "2023-06-17T19:51:45Z",
+    "messageCount": 3,
+    "recentMessages": [
+      {
+        "id": 90872,
+        "recipientId": 44091,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/432/200/200",
+        "relationship": "친구",
+        "content": "현빈님의 메세지 내용 71",
+        "font": "Noto Sans",
+        "createdAt": "2023-10-15T12:57:15Z"
+      },
+      {
+        "id": 73008,
+        "recipientId": 44091,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/85/200/200",
+        "relationship": "가족",
+        "content": "현빈님의 메세지 내용 90",
+        "font": "Pretendard",
+        "createdAt": "2023-04-07T01:47:17Z"
+      },
+      {
+        "id": 36229,
+        "recipientId": 44091,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/170/200/200",
+        "relationship": "동료",
+        "content": "이영준님의 메세지 내용 14",
+        "font": "Roboto",
+        "createdAt": "2023-04-30T21:52:02Z"
+      }
+    ],
+    "reactionCount": 73,
+    "topReactions": [
+      {
+        "id": 53118,
+        "emoji": "😁",
+        "count": 1
+      }
+    ]
+  },
+  {
+    "id": 54206,
+    "name": "현빈",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/54206/600/400",
+    "createdAt": "2023-08-11T12:31:06Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 9945,
+        "recipientId": 54206,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/203/200/200",
+        "relationship": "가족",
+        "content": "김하은님의 메세지 내용 34",
+        "font": "Noto Sans",
+        "createdAt": "2023-02-22T00:16:51Z"
+      },
+      {
+        "id": 35953,
+        "recipientId": 54206,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/13/200/200",
+        "relationship": "친구",
+        "content": "한지민님의 메세지 내용 42",
+        "font": "Pretendard",
+        "createdAt": "2023-03-14T13:18:54Z"
+      },
+      {
+        "id": 28726,
+        "recipientId": 54206,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/95/200/200",
+        "relationship": "동료",
+        "content": "한지민님의 메세지 내용 42",
+        "font": "Pretendard",
+        "createdAt": "2023-03-03T06:17:34Z"
+      }
+    ],
+    "reactionCount": 70,
+    "topReactions": [
+      {
+        "id": 60136,
+        "emoji": "😀",
+        "count": 7
+      },
+      {
+        "id": 45903,
+        "emoji": "🥹",
+        "count": 17
+      },
+      {
+        "id": 38212,
+        "emoji": "😀",
+        "count": 18
+      },
+      {
+        "id": 59414,
+        "emoji": "🥹",
+        "count": 5
+      }
+    ]
+  },
+  {
+    "id": 68370,
+    "name": "이영준",
+    "backgroundColor": "green",
+    "backgroundImageURL": null,
+    "createdAt": "2023-11-10T06:53:35Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 7950,
+        "recipientId": 68370,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/468/200/200",
+        "relationship": "가족",
+        "content": "송혜교님의 메세지 내용 76",
+        "font": "Noto Sans",
+        "createdAt": "2023-05-28T16:55:31Z"
+      },
+      {
+        "id": 41779,
+        "recipientId": 68370,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/495/200/200",
+        "relationship": "동료",
+        "content": "김하은님의 메세지 내용 66",
+        "font": "Roboto",
+        "createdAt": "2024-01-11T01:55:42Z"
+      },
+      {
+        "id": 18889,
+        "recipientId": 68370,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/208/200/200",
+        "relationship": "가족",
+        "content": "한지민님의 메세지 내용 9",
+        "font": "Pretendard",
+        "createdAt": "2023-06-23T17:19:26Z"
+      }
+    ],
+    "reactionCount": 9,
+    "topReactions": [
+      {
+        "id": 19392,
+        "emoji": "😁",
+        "count": 18
+      },
+      {
+        "id": 13700,
+        "emoji": "❤️",
+        "count": 12
+      },
+      {
+        "id": 50701,
+        "emoji": "😁",
+        "count": 6
+      },
+      {
+        "id": 28314,
+        "emoji": "❤️",
+        "count": 15
+      },
+      {
+        "id": 65318,
+        "emoji": "🥹",
+        "count": 19
+      }
+    ]
+  },
+  {
+    "id": 76323,
+    "name": "이영준",
+    "backgroundColor": "green",
+    "backgroundImageURL": null,
+    "createdAt": "2023-06-11T11:07:28Z",
+    "messageCount": 7,
+    "recentMessages": [
+      {
+        "id": 76226,
+        "recipientId": 76323,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/180/200/200",
+        "relationship": "지인",
+        "content": "한지민님의 메세지 내용 11",
+        "font": "Roboto",
+        "createdAt": "2023-11-14T15:14:43Z"
+      },
+      {
+        "id": 18283,
+        "recipientId": 76323,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/269/200/200",
+        "relationship": "가족",
+        "content": "이영준님의 메세지 내용 42",
+        "font": "Noto Sans",
+        "createdAt": "2023-11-18T21:30:13Z"
+      },
+      {
+        "id": 69571,
+        "recipientId": 76323,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/382/200/200",
+        "relationship": "동료",
+        "content": "김하은님의 메세지 내용 73",
+        "font": "Roboto",
+        "createdAt": "2023-08-26T00:28:35Z"
+      }
+    ],
+    "reactionCount": 43,
+    "topReactions": [
+      {
+        "id": 38169,
+        "emoji": "🥹",
+        "count": 6
+      }
+    ]
+  },
+  {
+    "id": 84073,
+    "name": "박서준",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2023-06-30T13:11:38Z",
+    "messageCount": 1,
+    "recentMessages": [
+      {
+        "id": 19945,
+        "recipientId": 84073,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/32/200/200",
+        "relationship": "지인",
+        "content": "전지현님의 메세지 내용 56",
+        "font": "Roboto",
+        "createdAt": "2023-10-19T03:38:48Z"
+      }
+    ],
+    "reactionCount": 36,
+    "topReactions": [
+      {
+        "id": 51242,
+        "emoji": "👍",
+        "count": 3
+      },
+      {
+        "id": 23565,
+        "emoji": "❤️",
+        "count": 8
+      },
+      {
+        "id": 37031,
+        "emoji": "🥹",
+        "count": 17
+      },
+      {
+        "id": 78779,
+        "emoji": "❤️",
+        "count": 9
+      }
+    ]
+  },
+  {
+    "id": 14176,
+    "name": "송혜교",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/14176/600/400",
+    "createdAt": "2023-07-14T11:33:05Z",
+    "messageCount": 7,
+    "recentMessages": [
+      {
+        "id": 80228,
+        "recipientId": 14176,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/221/200/200",
+        "relationship": "지인",
+        "content": "최민수님의 메세지 내용 44",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-11-19T19:29:11Z"
+      },
+      {
+        "id": 37,
+        "recipientId": 14176,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/289/200/200",
+        "relationship": "지인",
+        "content": "최민수님의 메세지 내용 69",
+        "font": "Pretendard",
+        "createdAt": "2023-05-30T17:54:20Z"
+      },
+      {
+        "id": 63293,
+        "recipientId": 14176,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/438/200/200",
+        "relationship": "지인",
+        "content": "최민수님의 메세지 내용 27",
+        "font": "Pretendard",
+        "createdAt": "2024-01-28T13:46:13Z"
+      }
+    ],
+    "reactionCount": 31,
+    "topReactions": [
+      {
+        "id": 50319,
+        "emoji": "😁",
+        "count": 20
+      },
+      {
+        "id": 44923,
+        "emoji": "🥹",
+        "count": 16
+      },
+      {
+        "id": 54729,
+        "emoji": "👍",
+        "count": 1
+      },
+      {
+        "id": 82072,
+        "emoji": "🎉",
+        "count": 11
+      },
+      {
+        "id": 10911,
+        "emoji": "😁",
+        "count": 2
+      }
+    ]
+  },
+  {
+    "id": 63278,
+    "name": "전지현",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/63278/600/400",
+    "createdAt": "2023-09-08T13:46:48Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 5278,
+        "recipientId": 63278,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/59/200/200",
+        "relationship": "친구",
+        "content": "김하은님의 메세지 내용 53",
+        "font": "Noto Sans",
+        "createdAt": "2023-06-01T20:26:14Z"
+      },
+      {
+        "id": 26283,
+        "recipientId": 63278,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/460/200/200",
+        "relationship": "지인",
+        "content": "송혜교님의 메세지 내용 41",
+        "font": "Pretendard",
+        "createdAt": "2023-09-26T17:49:04Z"
+      },
+      {
+        "id": 74629,
+        "recipientId": 63278,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/241/200/200",
+        "relationship": "친구",
+        "content": "전지현님의 메세지 내용 13",
+        "font": "Roboto",
+        "createdAt": "2023-10-28T13:39:12Z"
+      }
+    ],
+    "reactionCount": 48,
+    "topReactions": [
+      {
+        "id": 55639,
+        "emoji": "😁",
+        "count": 2
+      },
+      {
+        "id": 98809,
+        "emoji": "❤️",
+        "count": 2
+      },
+      {
+        "id": 69046,
+        "emoji": "👍",
+        "count": 2
+      }
+    ]
+  },
+  {
+    "id": 35291,
+    "name": "이영준",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2024-01-23T21:03:45Z",
+    "messageCount": 3,
+    "recentMessages": [
+      {
+        "id": 54804,
+        "recipientId": 35291,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/373/200/200",
+        "relationship": "가족",
+        "content": "현빈님의 메세지 내용 8",
+        "font": "Noto Sans",
+        "createdAt": "2023-04-14T15:39:03Z"
+      },
+      {
+        "id": 20544,
+        "recipientId": 35291,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/296/200/200",
+        "relationship": "가족",
+        "content": "현빈님의 메세지 내용 9",
+        "font": "Noto Sans",
+        "createdAt": "2023-11-15T13:00:19Z"
+      },
+      {
+        "id": 30666,
+        "recipientId": 35291,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/399/200/200",
+        "relationship": "친구",
+        "content": "송혜교님의 메세지 내용 88",
+        "font": "Noto Sans",
+        "createdAt": "2023-12-23T00:45:32Z"
+      }
+    ],
+    "reactionCount": 100,
+    "topReactions": [
+      {
+        "id": 4687,
+        "emoji": "❤️",
+        "count": 9
+      }
+    ]
+  },
+  {
+    "id": 3038,
+    "name": "현빈",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/3038/600/400",
+    "createdAt": "2023-06-27T03:39:55Z",
+    "messageCount": 9,
+    "recentMessages": [
+      {
+        "id": 95652,
+        "recipientId": 3038,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/450/200/200",
+        "relationship": "가족",
+        "content": "김하은님의 메세지 내용 45",
+        "font": "Roboto",
+        "createdAt": "2023-02-19T01:18:56Z"
+      },
+      {
+        "id": 52296,
+        "recipientId": 3038,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/131/200/200",
+        "relationship": "가족",
+        "content": "현빈님의 메세지 내용 41",
+        "font": "Noto Sans",
+        "createdAt": "2023-07-15T18:02:58Z"
+      },
+      {
+        "id": 55396,
+        "recipientId": 3038,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/146/200/200",
+        "relationship": "친구",
+        "content": "송혜교님의 메세지 내용 58",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-03-26T23:08:07Z"
+      }
+    ],
+    "reactionCount": 54,
+    "topReactions": [
+      {
+        "id": 5609,
+        "emoji": "🎉",
+        "count": 3
+      },
+      {
+        "id": 93922,
+        "emoji": "😁",
+        "count": 19
+      }
+    ]
+  },
+  {
+    "id": 62965,
+    "name": "한지민",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-01-16T23:39:19Z",
+    "messageCount": 6,
+    "recentMessages": [
+      {
+        "id": 10114,
+        "recipientId": 62965,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/281/200/200",
+        "relationship": "가족",
+        "content": "전지현님의 메세지 내용 40",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-09-27T11:32:49Z"
+      },
+      {
+        "id": 58525,
+        "recipientId": 62965,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/103/200/200",
+        "relationship": "친구",
+        "content": "이병헌님의 메세지 내용 1",
+        "font": "Noto Sans",
+        "createdAt": "2023-04-24T14:22:46Z"
+      },
+      {
+        "id": 20887,
+        "recipientId": 62965,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/318/200/200",
+        "relationship": "가족",
+        "content": "이영준님의 메세지 내용 36",
+        "font": "Pretendard",
+        "createdAt": "2023-05-07T12:50:11Z"
+      }
+    ],
+    "reactionCount": 74,
+    "topReactions": [
+      {
+        "id": 29181,
+        "emoji": "😁",
+        "count": 2
+      }
+    ]
+  },
+  {
+    "id": 61614,
+    "name": "송혜교",
+    "backgroundColor": "blue",
+    "backgroundImageURL": null,
+    "createdAt": "2024-01-27T06:28:36Z",
+    "messageCount": 10,
+    "recentMessages": [
+      {
+        "id": 86114,
+        "recipientId": 61614,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/1/200/200",
+        "relationship": "친구",
+        "content": "이병헌님의 메세지 내용 48",
+        "font": "Noto Sans",
+        "createdAt": "2023-11-16T04:24:55Z"
+      },
+      {
+        "id": 12648,
+        "recipientId": 61614,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/291/200/200",
+        "relationship": "가족",
+        "content": "전지현님의 메세지 내용 14",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-05-26T04:21:47Z"
+      },
+      {
+        "id": 36957,
+        "recipientId": 61614,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/356/200/200",
+        "relationship": "친구",
+        "content": "한지민님의 메세지 내용 26",
+        "font": "Pretendard",
+        "createdAt": "2023-02-09T04:44:09Z"
+      }
+    ],
+    "reactionCount": 43,
+    "topReactions": [
+      {
+        "id": 96270,
+        "emoji": "😁",
+        "count": 8
+      },
+      {
+        "id": 86470,
+        "emoji": "👍",
+        "count": 20
+      },
+      {
+        "id": 73582,
+        "emoji": "😁",
+        "count": 18
+      }
+    ]
+  },
+  {
+    "id": 69902,
+    "name": "송혜교",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/69902/600/400",
+    "createdAt": "2024-01-18T11:46:07Z",
+    "messageCount": 7,
+    "recentMessages": [
+      {
+        "id": 9049,
+        "recipientId": 69902,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/185/200/200",
+        "relationship": "동료",
+        "content": "전지현님의 메세지 내용 57",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-09-26T03:46:33Z"
+      },
+      {
+        "id": 54860,
+        "recipientId": 69902,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/322/200/200",
+        "relationship": "친구",
+        "content": "김하은님의 메세지 내용 46",
+        "font": "Pretendard",
+        "createdAt": "2023-03-14T16:52:38Z"
+      },
+      {
+        "id": 46217,
+        "recipientId": 69902,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/307/200/200",
+        "relationship": "가족",
+        "content": "박서준님의 메세지 내용 89",
+        "font": "Roboto",
+        "createdAt": "2023-12-09T06:45:19Z"
+      }
+    ],
+    "reactionCount": 59,
+    "topReactions": [
+      {
+        "id": 10874,
+        "emoji": "❤️",
+        "count": 20
+      },
+      {
+        "id": 9648,
+        "emoji": "🥹",
+        "count": 8
+      },
+      {
+        "id": 90543,
+        "emoji": "👍",
+        "count": 3
+      }
+    ]
+  },
+  {
+    "id": 31146,
+    "name": "이병헌",
+    "backgroundColor": "green",
+    "backgroundImageURL": null,
+    "createdAt": "2023-09-27T13:42:38Z",
+    "messageCount": 1,
+    "recentMessages": [
+      {
+        "id": 55285,
+        "recipientId": 31146,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/175/200/200",
+        "relationship": "친구",
+        "content": "한지민님의 메세지 내용 1",
+        "font": "Pretendard",
+        "createdAt": "2024-01-20T10:25:39Z"
+      }
+    ],
+    "reactionCount": 88,
+    "topReactions": [
+      {
+        "id": 90630,
+        "emoji": "🥹",
+        "count": 8
+      },
+      {
+        "id": 31427,
+        "emoji": "🎉",
+        "count": 13
+      },
+      {
+        "id": 40617,
+        "emoji": "🎉",
+        "count": 19
+      },
+      {
+        "id": 21215,
+        "emoji": "🎉",
+        "count": 1
+      },
+      {
+        "id": 10418,
+        "emoji": "😀",
+        "count": 10
+      }
+    ]
+  },
+  {
+    "id": 99123,
+    "name": "김하은",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2023-06-15T07:28:57Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 80875,
+        "recipientId": 99123,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/42/200/200",
+        "relationship": "동료",
+        "content": "이병헌님의 메세지 내용 14",
+        "font": "Roboto",
+        "createdAt": "2023-11-30T19:44:40Z"
+      },
+      {
+        "id": 55841,
+        "recipientId": 99123,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/377/200/200",
+        "relationship": "지인",
+        "content": "한지민님의 메세지 내용 80",
+        "font": "Roboto",
+        "createdAt": "2023-10-22T05:25:33Z"
+      },
+      {
+        "id": 10401,
+        "recipientId": 99123,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/289/200/200",
+        "relationship": "친구",
+        "content": "한지민님의 메세지 내용 29",
+        "font": "Roboto",
+        "createdAt": "2023-04-03T21:19:09Z"
+      }
+    ],
+    "reactionCount": 80,
+    "topReactions": [
+      {
+        "id": 24281,
+        "emoji": "😁",
+        "count": 12
+      },
+      {
+        "id": 56612,
+        "emoji": "❤️",
+        "count": 8
+      }
+    ]
+  },
+  {
+    "id": 23460,
+    "name": "전지현",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/23460/600/400",
+    "createdAt": "2023-11-01T19:37:56Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 6131,
+        "recipientId": 23460,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/223/200/200",
+        "relationship": "가족",
+        "content": "최민수님의 메세지 내용 60",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-06-21T09:22:34Z"
+      },
+      {
+        "id": 99333,
+        "recipientId": 23460,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/43/200/200",
+        "relationship": "동료",
+        "content": "박서준님의 메세지 내용 100",
+        "font": "Pretendard",
+        "createdAt": "2023-10-17T20:43:17Z"
+      },
+      {
+        "id": 15452,
+        "recipientId": 23460,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/357/200/200",
+        "relationship": "가족",
+        "content": "전지현님의 메세지 내용 72",
+        "font": "Pretendard",
+        "createdAt": "2023-10-12T19:29:28Z"
+      }
+    ],
+    "reactionCount": 83,
+    "topReactions": [
+      {
+        "id": 41395,
+        "emoji": "❤️",
+        "count": 3
+      },
+      {
+        "id": 71463,
+        "emoji": "😁",
+        "count": 14
+      },
+      {
+        "id": 43684,
+        "emoji": "🎉",
+        "count": 20
+      }
+    ]
+  },
+  {
+    "id": 16143,
+    "name": "박서준",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/16143/600/400",
+    "createdAt": "2023-01-04T22:33:04Z",
+    "messageCount": 10,
+    "recentMessages": [
+      {
+        "id": 29397,
+        "recipientId": 16143,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/42/200/200",
+        "relationship": "가족",
+        "content": "최민수님의 메세지 내용 18",
+        "font": "Pretendard",
+        "createdAt": "2023-10-28T19:38:42Z"
+      },
+      {
+        "id": 61587,
+        "recipientId": 16143,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/355/200/200",
+        "relationship": "가족",
+        "content": "정우성님의 메세지 내용 12",
+        "font": "Noto Sans",
+        "createdAt": "2023-10-08T06:13:32Z"
+      },
+      {
+        "id": 9237,
+        "recipientId": 16143,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/437/200/200",
+        "relationship": "지인",
+        "content": "이병헌님의 메세지 내용 14",
+        "font": "Pretendard",
+        "createdAt": "2023-03-17T21:44:08Z"
+      }
+    ],
+    "reactionCount": 77,
+    "topReactions": [
+      {
+        "id": 18467,
+        "emoji": "👍",
+        "count": 17
+      },
+      {
+        "id": 28382,
+        "emoji": "😀",
+        "count": 1
+      },
+      {
+        "id": 94572,
+        "emoji": "❤️",
+        "count": 1
+      },
+      {
+        "id": 63127,
+        "emoji": "🥹",
+        "count": 16
+      }
+    ]
+  },
+  {
+    "id": 68350,
+    "name": "송혜교",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/68350/600/400",
+    "createdAt": "2023-03-04T17:34:20Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 34771,
+        "recipientId": 68350,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/133/200/200",
+        "relationship": "가족",
+        "content": "정우성님의 메세지 내용 74",
+        "font": "Roboto",
+        "createdAt": "2023-08-04T20:53:43Z"
+      },
+      {
+        "id": 3254,
+        "recipientId": 68350,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/10/200/200",
+        "relationship": "가족",
+        "content": "한지민님의 메세지 내용 14",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-10-10T20:43:09Z"
+      },
+      {
+        "id": 57267,
+        "recipientId": 68350,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/183/200/200",
+        "relationship": "지인",
+        "content": "송혜교님의 메세지 내용 82",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-02-14T21:40:55Z"
+      }
+    ],
+    "reactionCount": 61,
+    "topReactions": [
+      {
+        "id": 99369,
+        "emoji": "👍",
+        "count": 6
+      }
+    ]
+  },
+  {
+    "id": 98422,
+    "name": "한지민",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2023-07-31T00:35:56Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 25200,
+        "recipientId": 98422,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/380/200/200",
+        "relationship": "지인",
+        "content": "현빈님의 메세지 내용 46",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-02-10T09:22:21Z"
+      },
+      {
+        "id": 12390,
+        "recipientId": 98422,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/70/200/200",
+        "relationship": "지인",
+        "content": "김하은님의 메세지 내용 31",
+        "font": "Noto Sans",
+        "createdAt": "2023-03-27T15:05:54Z"
+      },
+      {
+        "id": 31892,
+        "recipientId": 98422,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/8/200/200",
+        "relationship": "지인",
+        "content": "이병헌님의 메세지 내용 43",
+        "font": "Pretendard",
+        "createdAt": "2023-09-02T03:23:20Z"
+      }
+    ],
+    "reactionCount": 6,
+    "topReactions": [
+      {
+        "id": 99679,
+        "emoji": "👍",
+        "count": 1
+      },
+      {
+        "id": 42127,
+        "emoji": "👍",
+        "count": 20
+      },
+      {
+        "id": 49549,
+        "emoji": "😀",
+        "count": 5
+      }
+    ]
+  },
+  {
+    "id": 53532,
+    "name": "이영준",
+    "backgroundColor": "green",
+    "backgroundImageURL": null,
+    "createdAt": "2023-12-08T09:44:53Z",
+    "messageCount": 9,
+    "recentMessages": [
+      {
+        "id": 33230,
+        "recipientId": 53532,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/231/200/200",
+        "relationship": "친구",
+        "content": "정우성님의 메세지 내용 27",
+        "font": "Pretendard",
+        "createdAt": "2023-12-05T13:46:34Z"
+      },
+      {
+        "id": 85445,
+        "recipientId": 53532,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/363/200/200",
+        "relationship": "지인",
+        "content": "이병헌님의 메세지 내용 51",
+        "font": "Noto Sans",
+        "createdAt": "2023-09-23T11:29:56Z"
+      },
+      {
+        "id": 5528,
+        "recipientId": 53532,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/376/200/200",
+        "relationship": "가족",
+        "content": "김하은님의 메세지 내용 72",
+        "font": "Pretendard",
+        "createdAt": "2023-05-22T16:07:40Z"
+      }
+    ],
+    "reactionCount": 59,
+    "topReactions": [
+      {
+        "id": 23496,
+        "emoji": "❤️",
+        "count": 18
+      },
+      {
+        "id": 81866,
+        "emoji": "👍",
+        "count": 10
+      },
+      {
+        "id": 17757,
+        "emoji": "🥹",
+        "count": 10
+      },
+      {
+        "id": 39750,
+        "emoji": "🥹",
+        "count": 16
+      },
+      {
+        "id": 24933,
+        "emoji": "😁",
+        "count": 12
+      },
+      {
+        "id": 26409,
+        "emoji": "❤️",
+        "count": 19
+      }
+    ]
+  },
+  {
+    "id": 93792,
+    "name": "김하은",
+    "backgroundColor": "blue",
+    "backgroundImageURL": null,
+    "createdAt": "2023-10-03T23:01:03Z",
+    "messageCount": 7,
+    "recentMessages": [
+      {
+        "id": 86518,
+        "recipientId": 93792,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/204/200/200",
+        "relationship": "지인",
+        "content": "이병헌님의 메세지 내용 9",
+        "font": "Roboto",
+        "createdAt": "2023-01-22T13:44:09Z"
+      },
+      {
+        "id": 99933,
+        "recipientId": 93792,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/36/200/200",
+        "relationship": "친구",
+        "content": "박서준님의 메세지 내용 47",
+        "font": "Roboto",
+        "createdAt": "2023-12-15T23:06:01Z"
+      },
+      {
+        "id": 9752,
+        "recipientId": 93792,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/171/200/200",
+        "relationship": "동료",
+        "content": "이병헌님의 메세지 내용 68",
+        "font": "Roboto",
+        "createdAt": "2023-02-15T23:39:35Z"
+      }
+    ],
+    "reactionCount": 52,
+    "topReactions": [
+      {
+        "id": 4867,
+        "emoji": "❤️",
+        "count": 19
+      },
+      {
+        "id": 39233,
+        "emoji": "🥹",
+        "count": 20
+      },
+      {
+        "id": 20026,
+        "emoji": "❤️",
+        "count": 19
+      },
+      {
+        "id": 72595,
+        "emoji": "👍",
+        "count": 13
+      },
+      {
+        "id": 13775,
+        "emoji": "🥹",
+        "count": 17
+      }
+    ]
+  },
+  {
+    "id": 12242,
+    "name": "송혜교",
+    "backgroundColor": "green",
+    "backgroundImageURL": null,
+    "createdAt": "2023-08-08T18:28:39Z",
+    "messageCount": 6,
+    "recentMessages": [
+      {
+        "id": 60783,
+        "recipientId": 12242,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/367/200/200",
+        "relationship": "친구",
+        "content": "박서준님의 메세지 내용 41",
+        "font": "Roboto",
+        "createdAt": "2023-08-22T03:44:05Z"
+      },
+      {
+        "id": 10949,
+        "recipientId": 12242,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/309/200/200",
+        "relationship": "동료",
+        "content": "박서준님의 메세지 내용 18",
+        "font": "Roboto",
+        "createdAt": "2023-04-22T04:41:36Z"
+      },
+      {
+        "id": 84648,
+        "recipientId": 12242,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/112/200/200",
+        "relationship": "친구",
+        "content": "이병헌님의 메세지 내용 4",
+        "font": "Pretendard",
+        "createdAt": "2024-01-06T11:37:10Z"
+      }
+    ],
+    "reactionCount": 61,
+    "topReactions": [
+      {
+        "id": 84557,
+        "emoji": "😀",
+        "count": 20
+      },
+      {
+        "id": 77673,
+        "emoji": "😀",
+        "count": 12
+      },
+      {
+        "id": 99493,
+        "emoji": "❤️",
+        "count": 13
+      },
+      {
+        "id": 67646,
+        "emoji": "🥹",
+        "count": 4
+      },
+      {
+        "id": 54419,
+        "emoji": "❤️",
+        "count": 12
+      },
+      {
+        "id": 2038,
+        "emoji": "🎉",
+        "count": 1
+      }
+    ]
+  },
+  {
+    "id": 89238,
+    "name": "현빈",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2023-07-30T22:16:57Z",
+    "messageCount": 2,
+    "recentMessages": [
+      {
+        "id": 80184,
+        "recipientId": 89238,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/280/200/200",
+        "relationship": "친구",
+        "content": "이영준님의 메세지 내용 79",
+        "font": "Pretendard",
+        "createdAt": "2023-08-21T11:18:34Z"
+      },
+      {
+        "id": 47050,
+        "recipientId": 89238,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/484/200/200",
+        "relationship": "동료",
+        "content": "김하은님의 메세지 내용 55",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-11-26T01:02:24Z"
+      }
+    ],
+    "reactionCount": 31,
+    "topReactions": [
+      {
+        "id": 72384,
+        "emoji": "🎉",
+        "count": 10
+      },
+      {
+        "id": 24751,
+        "emoji": "👍",
+        "count": 2
+      }
+    ]
+  },
+  {
+    "id": 76148,
+    "name": "김하은",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/76148/600/400",
+    "createdAt": "2023-09-05T06:37:33Z",
+    "messageCount": 2,
+    "recentMessages": [
+      {
+        "id": 6882,
+        "recipientId": 76148,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/124/200/200",
+        "relationship": "지인",
+        "content": "송혜교님의 메세지 내용 35",
+        "font": "Noto Sans",
+        "createdAt": "2024-01-24T04:11:44Z"
+      },
+      {
+        "id": 35816,
+        "recipientId": 76148,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/488/200/200",
+        "relationship": "가족",
+        "content": "이병헌님의 메세지 내용 96",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-04-09T14:21:56Z"
+      }
+    ],
+    "reactionCount": 3,
+    "topReactions": [
+      {
+        "id": 24742,
+        "emoji": "🥹",
+        "count": 11
+      },
+      {
+        "id": 31827,
+        "emoji": "👍",
+        "count": 6
+      },
+      {
+        "id": 12947,
+        "emoji": "🎉",
+        "count": 5
+      },
+      {
+        "id": 40799,
+        "emoji": "🎉",
+        "count": 3
+      }
+    ]
+  },
+  {
+    "id": 30844,
+    "name": "한지민",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/30844/600/400",
+    "createdAt": "2023-10-28T15:58:37Z",
+    "messageCount": 2,
+    "recentMessages": [
+      {
+        "id": 80665,
+        "recipientId": 30844,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/114/200/200",
+        "relationship": "지인",
+        "content": "이영준님의 메세지 내용 46",
+        "font": "Pretendard",
+        "createdAt": "2024-01-04T21:06:58Z"
+      },
+      {
+        "id": 51843,
+        "recipientId": 30844,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/494/200/200",
+        "relationship": "친구",
+        "content": "이영준님의 메세지 내용 47",
+        "font": "Noto Sans",
+        "createdAt": "2023-03-25T15:03:22Z"
+      }
+    ],
+    "reactionCount": 50,
+    "topReactions": [
+      {
+        "id": 99751,
+        "emoji": "❤️",
+        "count": 16
+      }
+    ]
+  },
+  {
+    "id": 38642,
+    "name": "정우성",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/38642/600/400",
+    "createdAt": "2023-12-23T15:10:53Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 76780,
+        "recipientId": 38642,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/253/200/200",
+        "relationship": "가족",
+        "content": "이병헌님의 메세지 내용 24",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-07-12T11:54:03Z"
+      },
+      {
+        "id": 97730,
+        "recipientId": 38642,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/24/200/200",
+        "relationship": "동료",
+        "content": "박서준님의 메세지 내용 89",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-01-10T18:45:35Z"
+      },
+      {
+        "id": 64400,
+        "recipientId": 38642,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/47/200/200",
+        "relationship": "가족",
+        "content": "박서준님의 메세지 내용 21",
+        "font": "Roboto",
+        "createdAt": "2023-04-13T02:41:12Z"
+      }
+    ],
+    "reactionCount": 29,
+    "topReactions": [
+      {
+        "id": 96587,
+        "emoji": "😁",
+        "count": 16
+      },
+      {
+        "id": 33006,
+        "emoji": "🎉",
+        "count": 8
+      },
+      {
+        "id": 4665,
+        "emoji": "🎉",
+        "count": 3
+      },
+      {
+        "id": 6761,
+        "emoji": "😀",
+        "count": 7
+      }
+    ]
+  },
+  {
+    "id": 19180,
+    "name": "한지민",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2023-03-17T02:54:43Z",
+    "messageCount": 2,
+    "recentMessages": [
+      {
+        "id": 99404,
+        "recipientId": 19180,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/72/200/200",
+        "relationship": "가족",
+        "content": "송혜교님의 메세지 내용 34",
+        "font": "Noto Sans",
+        "createdAt": "2023-12-31T06:59:44Z"
+      },
+      {
+        "id": 40694,
+        "recipientId": 19180,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/466/200/200",
+        "relationship": "동료",
+        "content": "이영준님의 메세지 내용 85",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-05-15T12:04:48Z"
+      }
+    ],
+    "reactionCount": 29,
+    "topReactions": [
+      {
+        "id": 85255,
+        "emoji": "😀",
+        "count": 10
+      }
+    ]
+  },
+  {
+    "id": 56954,
+    "name": "이영준",
+    "backgroundColor": "blue",
+    "backgroundImageURL": null,
+    "createdAt": "2023-07-08T16:30:01Z",
+    "messageCount": 10,
+    "recentMessages": [
+      {
+        "id": 77321,
+        "recipientId": 56954,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/486/200/200",
+        "relationship": "가족",
+        "content": "최민수님의 메세지 내용 71",
+        "font": "Pretendard",
+        "createdAt": "2024-01-10T14:52:33Z"
+      },
+      {
+        "id": 48997,
+        "recipientId": 56954,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/128/200/200",
+        "relationship": "친구",
+        "content": "현빈님의 메세지 내용 8",
+        "font": "Pretendard",
+        "createdAt": "2023-10-26T08:26:46Z"
+      },
+      {
+        "id": 39251,
+        "recipientId": 56954,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/491/200/200",
+        "relationship": "지인",
+        "content": "최민수님의 메세지 내용 63",
+        "font": "Roboto",
+        "createdAt": "2023-06-07T05:35:20Z"
+      }
+    ],
+    "reactionCount": 15,
+    "topReactions": [
+      {
+        "id": 93584,
+        "emoji": "🥹",
+        "count": 17
+      },
+      {
+        "id": 64509,
+        "emoji": "🥹",
+        "count": 7
+      },
+      {
+        "id": 26383,
+        "emoji": "❤️",
+        "count": 11
+      },
+      {
+        "id": 18223,
+        "emoji": "🥹",
+        "count": 6
+      }
+    ]
+  },
+  {
+    "id": 69809,
+    "name": "김하은",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/69809/600/400",
+    "createdAt": "2023-12-17T10:40:55Z",
+    "messageCount": 2,
+    "recentMessages": [
+      {
+        "id": 99531,
+        "recipientId": 69809,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/454/200/200",
+        "relationship": "지인",
+        "content": "이영준님의 메세지 내용 11",
+        "font": "Pretendard",
+        "createdAt": "2023-12-21T11:49:22Z"
+      },
+      {
+        "id": 50525,
+        "recipientId": 69809,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/426/200/200",
+        "relationship": "지인",
+        "content": "박서준님의 메세지 내용 67",
+        "font": "Pretendard",
+        "createdAt": "2023-10-31T11:25:46Z"
+      }
+    ],
+    "reactionCount": 91,
+    "topReactions": [
+      {
+        "id": 12819,
+        "emoji": "🎉",
+        "count": 16
+      },
+      {
+        "id": 51793,
+        "emoji": "❤️",
+        "count": 8
+      },
+      {
+        "id": 47344,
+        "emoji": "❤️",
+        "count": 9
+      }
+    ]
+  },
+  {
+    "id": 55884,
+    "name": "전지현",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/55884/600/400",
+    "createdAt": "2023-05-07T09:10:12Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 78207,
+        "recipientId": 55884,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/155/200/200",
+        "relationship": "지인",
+        "content": "이병헌님의 메세지 내용 87",
+        "font": "Pretendard",
+        "createdAt": "2023-06-01T07:21:37Z"
+      },
+      {
+        "id": 52755,
+        "recipientId": 55884,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/148/200/200",
+        "relationship": "친구",
+        "content": "최민수님의 메세지 내용 76",
+        "font": "Pretendard",
+        "createdAt": "2023-11-02T00:07:24Z"
+      },
+      {
+        "id": 96898,
+        "recipientId": 55884,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/468/200/200",
+        "relationship": "동료",
+        "content": "전지현님의 메세지 내용 21",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-02-17T02:04:29Z"
+      }
+    ],
+    "reactionCount": 53,
+    "topReactions": [
+      {
+        "id": 48355,
+        "emoji": "👍",
+        "count": 6
+      },
+      {
+        "id": 38418,
+        "emoji": "👍",
+        "count": 13
+      },
+      {
+        "id": 7995,
+        "emoji": "😀",
+        "count": 20
+      },
+      {
+        "id": 55879,
+        "emoji": "🥹",
+        "count": 5
+      }
+    ]
+  },
+  {
+    "id": 65809,
+    "name": "최민수",
+    "backgroundColor": "green",
+    "backgroundImageURL": null,
+    "createdAt": "2023-01-13T12:44:51Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 2300,
+        "recipientId": 65809,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/358/200/200",
+        "relationship": "지인",
+        "content": "이병헌님의 메세지 내용 60",
+        "font": "Roboto",
+        "createdAt": "2023-05-12T09:25:19Z"
+      },
+      {
+        "id": 77937,
+        "recipientId": 65809,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/415/200/200",
+        "relationship": "지인",
+        "content": "정우성님의 메세지 내용 31",
+        "font": "Pretendard",
+        "createdAt": "2023-01-20T00:38:18Z"
+      },
+      {
+        "id": 23083,
+        "recipientId": 65809,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/239/200/200",
+        "relationship": "가족",
+        "content": "송혜교님의 메세지 내용 30",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-01-16T00:10:43Z"
+      }
+    ],
+    "reactionCount": 93,
+    "topReactions": [
+      {
+        "id": 51783,
+        "emoji": "🎉",
+        "count": 10
+      },
+      {
+        "id": 37523,
+        "emoji": "❤️",
+        "count": 19
+      },
+      {
+        "id": 58371,
+        "emoji": "😁",
+        "count": 16
+      },
+      {
+        "id": 83933,
+        "emoji": "😀",
+        "count": 10
+      },
+      {
+        "id": 67432,
+        "emoji": "❤️",
+        "count": 17
+      },
+      {
+        "id": 37226,
+        "emoji": "😀",
+        "count": 15
+      }
+    ]
+  },
+  {
+    "id": 47549,
+    "name": "김하은",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2023-11-16T19:12:33Z",
+    "messageCount": 9,
+    "recentMessages": [
+      {
+        "id": 12155,
+        "recipientId": 47549,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/247/200/200",
+        "relationship": "지인",
+        "content": "이병헌님의 메세지 내용 80",
+        "font": "Pretendard",
+        "createdAt": "2023-03-09T22:19:14Z"
+      },
+      {
+        "id": 97085,
+        "recipientId": 47549,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/468/200/200",
+        "relationship": "친구",
+        "content": "이영준님의 메세지 내용 24",
+        "font": "Pretendard",
+        "createdAt": "2023-05-15T13:22:05Z"
+      },
+      {
+        "id": 38570,
+        "recipientId": 47549,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/485/200/200",
+        "relationship": "동료",
+        "content": "이영준님의 메세지 내용 42",
+        "font": "Nanum Gothic",
+        "createdAt": "2024-01-05T09:02:07Z"
+      }
+    ],
+    "reactionCount": 73,
+    "topReactions": [
+      {
+        "id": 6824,
+        "emoji": "🎉",
+        "count": 1
+      },
+      {
+        "id": 77828,
+        "emoji": "😀",
+        "count": 14
+      },
+      {
+        "id": 10712,
+        "emoji": "🥹",
+        "count": 8
+      },
+      {
+        "id": 14431,
+        "emoji": "❤️",
+        "count": 5
+      },
+      {
+        "id": 41886,
+        "emoji": "🎉",
+        "count": 15
+      },
+      {
+        "id": 38043,
+        "emoji": "❤️",
+        "count": 7
+      }
+    ]
+  },
+  {
+    "id": 7135,
+    "name": "이영준",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/7135/600/400",
+    "createdAt": "2024-02-02T00:26:07Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 77121,
+        "recipientId": 7135,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/494/200/200",
+        "relationship": "지인",
+        "content": "정우성님의 메세지 내용 47",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-12-03T15:32:07Z"
+      },
+      {
+        "id": 38873,
+        "recipientId": 7135,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/166/200/200",
+        "relationship": "친구",
+        "content": "정우성님의 메세지 내용 52",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-12-30T01:58:20Z"
+      },
+      {
+        "id": 64811,
+        "recipientId": 7135,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/184/200/200",
+        "relationship": "친구",
+        "content": "이병헌님의 메세지 내용 9",
+        "font": "Roboto",
+        "createdAt": "2023-10-17T00:36:13Z"
+      }
+    ],
+    "reactionCount": 80,
+    "topReactions": [
+      {
+        "id": 73068,
+        "emoji": "😁",
+        "count": 14
+      }
+    ]
+  },
+  {
+    "id": 83536,
+    "name": "이영준",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2024-02-02T17:56:51Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 76208,
+        "recipientId": 83536,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/12/200/200",
+        "relationship": "동료",
+        "content": "최민수님의 메세지 내용 1",
+        "font": "Noto Sans",
+        "createdAt": "2023-11-26T03:41:54Z"
+      },
+      {
+        "id": 43421,
+        "recipientId": 83536,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/66/200/200",
+        "relationship": "가족",
+        "content": "정우성님의 메세지 내용 99",
+        "font": "Roboto",
+        "createdAt": "2023-01-23T15:07:50Z"
+      },
+      {
+        "id": 78732,
+        "recipientId": 83536,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/385/200/200",
+        "relationship": "동료",
+        "content": "전지현님의 메세지 내용 41",
+        "font": "Pretendard",
+        "createdAt": "2023-08-24T20:58:06Z"
+      }
+    ],
+    "reactionCount": 0,
+    "topReactions": [
+      {
+        "id": 64631,
+        "emoji": "❤️",
+        "count": 7
+      },
+      {
+        "id": 15818,
+        "emoji": "❤️",
+        "count": 6
+      },
+      {
+        "id": 96523,
+        "emoji": "❤️",
+        "count": 3
+      },
+      {
+        "id": 87388,
+        "emoji": "🎉",
+        "count": 19
+      },
+      {
+        "id": 64648,
+        "emoji": "👍",
+        "count": 4
+      }
+    ]
+  },
+  {
+    "id": 61585,
+    "name": "한지민",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/61585/600/400",
+    "createdAt": "2023-11-08T05:35:02Z",
+    "messageCount": 6,
+    "recentMessages": [
+      {
+        "id": 27357,
+        "recipientId": 61585,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/165/200/200",
+        "relationship": "가족",
+        "content": "정우성님의 메세지 내용 31",
+        "font": "Pretendard",
+        "createdAt": "2023-09-11T11:00:09Z"
+      },
+      {
+        "id": 67752,
+        "recipientId": 61585,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/316/200/200",
+        "relationship": "친구",
+        "content": "한지민님의 메세지 내용 77",
+        "font": "Pretendard",
+        "createdAt": "2023-10-11T21:08:05Z"
+      },
+      {
+        "id": 39794,
+        "recipientId": 61585,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/247/200/200",
+        "relationship": "가족",
+        "content": "송혜교님의 메세지 내용 9",
+        "font": "Roboto",
+        "createdAt": "2023-06-17T12:32:47Z"
+      }
+    ],
+    "reactionCount": 54,
+    "topReactions": [
+      {
+        "id": 38019,
+        "emoji": "😀",
+        "count": 5
+      },
+      {
+        "id": 97709,
+        "emoji": "😁",
+        "count": 17
+      },
+      {
+        "id": 46872,
+        "emoji": "👍",
+        "count": 1
+      }
+    ]
+  },
+  {
+    "id": 4404,
+    "name": "전지현",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/4404/600/400",
+    "createdAt": "2023-12-06T02:26:16Z",
+    "messageCount": 10,
+    "recentMessages": [
+      {
+        "id": 6292,
+        "recipientId": 4404,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/252/200/200",
+        "relationship": "지인",
+        "content": "최민수님의 메세지 내용 51",
+        "font": "Noto Sans",
+        "createdAt": "2023-01-23T16:41:53Z"
+      },
+      {
+        "id": 61157,
+        "recipientId": 4404,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/109/200/200",
+        "relationship": "가족",
+        "content": "송혜교님의 메세지 내용 95",
+        "font": "Roboto",
+        "createdAt": "2023-02-23T01:59:59Z"
+      },
+      {
+        "id": 82143,
+        "recipientId": 4404,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/156/200/200",
+        "relationship": "가족",
+        "content": "최민수님의 메세지 내용 45",
+        "font": "Roboto",
+        "createdAt": "2023-11-05T04:40:09Z"
+      }
+    ],
+    "reactionCount": 2,
+    "topReactions": [
+      {
+        "id": 10319,
+        "emoji": "🥹",
+        "count": 19
+      },
+      {
+        "id": 88672,
+        "emoji": "🎉",
+        "count": 18
+      }
+    ]
+  },
+  {
+    "id": 82511,
+    "name": "최민수",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2023-03-20T04:58:27Z",
+    "messageCount": 10,
+    "recentMessages": [
+      {
+        "id": 26463,
+        "recipientId": 82511,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/71/200/200",
+        "relationship": "지인",
+        "content": "이영준님의 메세지 내용 76",
+        "font": "Pretendard",
+        "createdAt": "2023-12-01T01:16:39Z"
+      },
+      {
+        "id": 2416,
+        "recipientId": 82511,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/268/200/200",
+        "relationship": "친구",
+        "content": "정우성님의 메세지 내용 24",
+        "font": "Noto Sans",
+        "createdAt": "2024-01-04T09:08:19Z"
+      },
+      {
+        "id": 50351,
+        "recipientId": 82511,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/389/200/200",
+        "relationship": "가족",
+        "content": "전지현님의 메세지 내용 9",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-03-28T23:52:37Z"
+      }
+    ],
+    "reactionCount": 56,
+    "topReactions": [
+      {
+        "id": 82148,
+        "emoji": "😀",
+        "count": 5
+      },
+      {
+        "id": 99162,
+        "emoji": "😀",
+        "count": 20
+      },
+      {
+        "id": 60338,
+        "emoji": "🎉",
+        "count": 20
+      },
+      {
+        "id": 99668,
+        "emoji": "👍",
+        "count": 10
+      }
+    ]
+  },
+  {
+    "id": 80845,
+    "name": "현빈",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/80845/600/400",
+    "createdAt": "2023-09-23T05:25:24Z",
+    "messageCount": 7,
+    "recentMessages": [
+      {
+        "id": 59713,
+        "recipientId": 80845,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/85/200/200",
+        "relationship": "지인",
+        "content": "현빈님의 메세지 내용 90",
+        "font": "Noto Sans",
+        "createdAt": "2023-07-28T08:33:36Z"
+      },
+      {
+        "id": 74833,
+        "recipientId": 80845,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/497/200/200",
+        "relationship": "동료",
+        "content": "정우성님의 메세지 내용 82",
+        "font": "Noto Sans",
+        "createdAt": "2024-01-15T11:55:15Z"
+      },
+      {
+        "id": 44164,
+        "recipientId": 80845,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/135/200/200",
+        "relationship": "동료",
+        "content": "최민수님의 메세지 내용 40",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-09-13T20:47:57Z"
+      }
+    ],
+    "reactionCount": 4,
+    "topReactions": [
+      {
+        "id": 2410,
+        "emoji": "👍",
+        "count": 7
+      },
+      {
+        "id": 46152,
+        "emoji": "😀",
+        "count": 4
+      },
+      {
+        "id": 98175,
+        "emoji": "🎉",
+        "count": 1
+      }
+    ]
+  },
+  {
+    "id": 11012,
+    "name": "최민수",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/11012/600/400",
+    "createdAt": "2023-09-24T11:28:28Z",
+    "messageCount": 7,
+    "recentMessages": [
+      {
+        "id": 4989,
+        "recipientId": 11012,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/380/200/200",
+        "relationship": "동료",
+        "content": "현빈님의 메세지 내용 51",
+        "font": "Pretendard",
+        "createdAt": "2023-01-09T06:31:52Z"
+      },
+      {
+        "id": 49460,
+        "recipientId": 11012,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/87/200/200",
+        "relationship": "친구",
+        "content": "한지민님의 메세지 내용 7",
+        "font": "Noto Sans",
+        "createdAt": "2023-11-01T20:42:58Z"
+      },
+      {
+        "id": 33477,
+        "recipientId": 11012,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/499/200/200",
+        "relationship": "동료",
+        "content": "김하은님의 메세지 내용 100",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-12-19T22:24:58Z"
+      }
+    ],
+    "reactionCount": 24,
+    "topReactions": [
+      {
+        "id": 8056,
+        "emoji": "🥹",
+        "count": 17
+      },
+      {
+        "id": 73087,
+        "emoji": "❤️",
+        "count": 2
+      }
+    ]
+  },
+  {
+    "id": 6792,
+    "name": "송혜교",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-11-20T08:02:43Z",
+    "messageCount": 2,
+    "recentMessages": [
+      {
+        "id": 30090,
+        "recipientId": 6792,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/140/200/200",
+        "relationship": "지인",
+        "content": "송혜교님의 메세지 내용 5",
+        "font": "Roboto",
+        "createdAt": "2023-01-30T10:59:51Z"
+      },
+      {
+        "id": 55978,
+        "recipientId": 6792,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/461/200/200",
+        "relationship": "지인",
+        "content": "전지현님의 메세지 내용 59",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-10-23T19:12:56Z"
+      }
+    ],
+    "reactionCount": 31,
+    "topReactions": [
+      {
+        "id": 58447,
+        "emoji": "😁",
+        "count": 18
+      }
+    ]
+  },
+  {
+    "id": 34708,
+    "name": "송혜교",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/34708/600/400",
+    "createdAt": "2023-02-10T16:28:04Z",
+    "messageCount": 6,
+    "recentMessages": [
+      {
+        "id": 6194,
+        "recipientId": 34708,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/317/200/200",
+        "relationship": "지인",
+        "content": "전지현님의 메세지 내용 47",
+        "font": "Pretendard",
+        "createdAt": "2023-06-08T17:46:33Z"
+      },
+      {
+        "id": 25345,
+        "recipientId": 34708,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/457/200/200",
+        "relationship": "동료",
+        "content": "정우성님의 메세지 내용 87",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-02-18T22:02:01Z"
+      },
+      {
+        "id": 84170,
+        "recipientId": 34708,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/327/200/200",
+        "relationship": "가족",
+        "content": "한지민님의 메세지 내용 70",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-05-02T00:06:39Z"
+      }
+    ],
+    "reactionCount": 28,
+    "topReactions": [
+      {
+        "id": 18524,
+        "emoji": "🎉",
+        "count": 5
+      },
+      {
+        "id": 46949,
+        "emoji": "😁",
+        "count": 16
+      },
+      {
+        "id": 76510,
+        "emoji": "😁",
+        "count": 12
+      },
+      {
+        "id": 81605,
+        "emoji": "😀",
+        "count": 19
+      },
+      {
+        "id": 66745,
+        "emoji": "🎉",
+        "count": 13
+      }
+    ]
+  },
+  {
+    "id": 21977,
+    "name": "현빈",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/21977/600/400",
+    "createdAt": "2024-02-05T18:34:45Z",
+    "messageCount": 2,
+    "recentMessages": [
+      {
+        "id": 75340,
+        "recipientId": 21977,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/86/200/200",
+        "relationship": "친구",
+        "content": "송혜교님의 메세지 내용 45",
+        "font": "Roboto",
+        "createdAt": "2024-01-09T13:48:43Z"
+      },
+      {
+        "id": 65322,
+        "recipientId": 21977,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/156/200/200",
+        "relationship": "친구",
+        "content": "이병헌님의 메세지 내용 79",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-09-13T04:30:55Z"
+      }
+    ],
+    "reactionCount": 76,
+    "topReactions": [
+      {
+        "id": 11821,
+        "emoji": "😀",
+        "count": 15
+      },
+      {
+        "id": 35147,
+        "emoji": "😁",
+        "count": 1
+      },
+      {
+        "id": 34644,
+        "emoji": "🎉",
+        "count": 5
+      }
+    ]
+  },
+  {
+    "id": 67245,
+    "name": "김하은",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-03-05T11:29:45Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 37649,
+        "recipientId": 67245,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/160/200/200",
+        "relationship": "지인",
+        "content": "이병헌님의 메세지 내용 84",
+        "font": "Roboto",
+        "createdAt": "2023-05-09T12:36:18Z"
+      },
+      {
+        "id": 98235,
+        "recipientId": 67245,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/320/200/200",
+        "relationship": "동료",
+        "content": "송혜교님의 메세지 내용 65",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-07-11T12:57:47Z"
+      },
+      {
+        "id": 922,
+        "recipientId": 67245,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/147/200/200",
+        "relationship": "지인",
+        "content": "전지현님의 메세지 내용 12",
+        "font": "Noto Sans",
+        "createdAt": "2023-10-05T12:35:41Z"
+      }
+    ],
+    "reactionCount": 35,
+    "topReactions": [
+      {
+        "id": 59116,
+        "emoji": "🥹",
+        "count": 1
+      },
+      {
+        "id": 49749,
+        "emoji": "😀",
+        "count": 6
+      },
+      {
+        "id": 9760,
+        "emoji": "❤️",
+        "count": 20
+      },
+      {
+        "id": 29620,
+        "emoji": "😀",
+        "count": 17
+      },
+      {
+        "id": 93360,
+        "emoji": "🥹",
+        "count": 5
+      },
+      {
+        "id": 55285,
+        "emoji": "🎉",
+        "count": 6
+      }
+    ]
+  },
+  {
+    "id": 60427,
+    "name": "정우성",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/60427/600/400",
+    "createdAt": "2023-01-14T01:31:34Z",
+    "messageCount": 9,
+    "recentMessages": [
+      {
+        "id": 14341,
+        "recipientId": 60427,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/68/200/200",
+        "relationship": "가족",
+        "content": "이영준님의 메세지 내용 5",
+        "font": "Pretendard",
+        "createdAt": "2023-09-09T16:01:13Z"
+      },
+      {
+        "id": 54177,
+        "recipientId": 60427,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/499/200/200",
+        "relationship": "동료",
+        "content": "박서준님의 메세지 내용 9",
+        "font": "Noto Sans",
+        "createdAt": "2023-03-18T17:17:13Z"
+      },
+      {
+        "id": 10188,
+        "recipientId": 60427,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/146/200/200",
+        "relationship": "친구",
+        "content": "이영준님의 메세지 내용 34",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-07-27T13:26:34Z"
+      }
+    ],
+    "reactionCount": 66,
+    "topReactions": [
+      {
+        "id": 93016,
+        "emoji": "❤️",
+        "count": 5
+      },
+      {
+        "id": 41560,
+        "emoji": "👍",
+        "count": 8
+      },
+      {
+        "id": 62205,
+        "emoji": "👍",
+        "count": 17
+      },
+      {
+        "id": 98001,
+        "emoji": "🥹",
+        "count": 4
+      }
+    ]
+  },
+  {
+    "id": 38317,
+    "name": "한지민",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/38317/600/400",
+    "createdAt": "2023-04-20T23:35:17Z",
+    "messageCount": 2,
+    "recentMessages": [
+      {
+        "id": 65804,
+        "recipientId": 38317,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/232/200/200",
+        "relationship": "친구",
+        "content": "최민수님의 메세지 내용 90",
+        "font": "Noto Sans",
+        "createdAt": "2023-04-13T15:24:49Z"
+      },
+      {
+        "id": 57545,
+        "recipientId": 38317,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/58/200/200",
+        "relationship": "친구",
+        "content": "송혜교님의 메세지 내용 14",
+        "font": "Pretendard",
+        "createdAt": "2023-08-15T18:35:26Z"
+      }
+    ],
+    "reactionCount": 100,
+    "topReactions": [
+      {
+        "id": 18600,
+        "emoji": "😁",
+        "count": 20
+      },
+      {
+        "id": 69649,
+        "emoji": "🥹",
+        "count": 14
+      },
+      {
+        "id": 61872,
+        "emoji": "🎉",
+        "count": 12
+      },
+      {
+        "id": 53627,
+        "emoji": "👍",
+        "count": 3
+      },
+      {
+        "id": 97051,
+        "emoji": "❤️",
+        "count": 17
+      },
+      {
+        "id": 91070,
+        "emoji": "🥹",
+        "count": 19
+      }
+    ]
+  },
+  {
+    "id": 14109,
+    "name": "박서준",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/14109/600/400",
+    "createdAt": "2023-06-01T08:10:27Z",
+    "messageCount": 9,
+    "recentMessages": [
+      {
+        "id": 78694,
+        "recipientId": 14109,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/359/200/200",
+        "relationship": "가족",
+        "content": "현빈님의 메세지 내용 93",
+        "font": "Nanum Gothic",
+        "createdAt": "2024-01-07T06:47:25Z"
+      },
+      {
+        "id": 98673,
+        "recipientId": 14109,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/291/200/200",
+        "relationship": "친구",
+        "content": "한지민님의 메세지 내용 2",
+        "font": "Roboto",
+        "createdAt": "2023-04-22T16:18:34Z"
+      },
+      {
+        "id": 48915,
+        "recipientId": 14109,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/254/200/200",
+        "relationship": "동료",
+        "content": "최민수님의 메세지 내용 7",
+        "font": "Noto Sans",
+        "createdAt": "2024-01-25T22:34:40Z"
+      }
+    ],
+    "reactionCount": 6,
+    "topReactions": [
+      {
+        "id": 61471,
+        "emoji": "❤️",
+        "count": 17
+      },
+      {
+        "id": 3871,
+        "emoji": "👍",
+        "count": 2
+      },
+      {
+        "id": 72869,
+        "emoji": "😀",
+        "count": 8
+      }
+    ]
+  },
+  {
+    "id": 50811,
+    "name": "이영준",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/50811/600/400",
+    "createdAt": "2023-10-02T05:46:37Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 87970,
+        "recipientId": 50811,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/28/200/200",
+        "relationship": "친구",
+        "content": "정우성님의 메세지 내용 73",
+        "font": "Noto Sans",
+        "createdAt": "2023-05-27T00:59:12Z"
+      },
+      {
+        "id": 27538,
+        "recipientId": 50811,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/256/200/200",
+        "relationship": "지인",
+        "content": "송혜교님의 메세지 내용 5",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-12-22T09:44:50Z"
+      },
+      {
+        "id": 73753,
+        "recipientId": 50811,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/148/200/200",
+        "relationship": "가족",
+        "content": "최민수님의 메세지 내용 39",
+        "font": "Noto Sans",
+        "createdAt": "2023-04-26T05:07:35Z"
+      }
+    ],
+    "reactionCount": 65,
+    "topReactions": [
+      {
+        "id": 92606,
+        "emoji": "😁",
+        "count": 4
+      },
+      {
+        "id": 38991,
+        "emoji": "👍",
+        "count": 8
+      },
+      {
+        "id": 59355,
+        "emoji": "🥹",
+        "count": 3
+      },
+      {
+        "id": 54969,
+        "emoji": "🥹",
+        "count": 6
+      },
+      {
+        "id": 33347,
+        "emoji": "🥹",
+        "count": 8
+      },
+      {
+        "id": 92921,
+        "emoji": "🎉",
+        "count": 13
+      }
+    ]
+  },
+  {
+    "id": 6155,
+    "name": "전지현",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/seed/6155/600/400",
+    "createdAt": "2023-07-14T13:41:34Z",
+    "messageCount": 1,
+    "recentMessages": [
+      {
+        "id": 3243,
+        "recipientId": 6155,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/318/200/200",
+        "relationship": "동료",
+        "content": "정우성님의 메세지 내용 52",
+        "font": "Noto Sans",
+        "createdAt": "2023-08-11T03:36:35Z"
+      }
+    ],
+    "reactionCount": 83,
+    "topReactions": [
+      {
+        "id": 30441,
+        "emoji": "❤️",
+        "count": 1
+      },
+      {
+        "id": 39751,
+        "emoji": "😁",
+        "count": 20
+      },
+      {
+        "id": 53520,
+        "emoji": "😀",
+        "count": 20
+      },
+      {
+        "id": 10975,
+        "emoji": "👍",
+        "count": 7
+      }
+    ]
+  },
+  {
+    "id": 56213,
+    "name": "현빈",
+    "backgroundColor": "green",
+    "backgroundImageURL": null,
+    "createdAt": "2023-09-15T20:40:35Z",
+    "messageCount": 7,
+    "recentMessages": [
+      {
+        "id": 73057,
+        "recipientId": 56213,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/33/200/200",
+        "relationship": "지인",
+        "content": "박서준님의 메세지 내용 81",
+        "font": "Roboto",
+        "createdAt": "2023-07-25T17:44:57Z"
+      },
+      {
+        "id": 89592,
+        "recipientId": 56213,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/310/200/200",
+        "relationship": "동료",
+        "content": "정우성님의 메세지 내용 33",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-07-16T12:03:19Z"
+      },
+      {
+        "id": 94221,
+        "recipientId": 56213,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/264/200/200",
+        "relationship": "친구",
+        "content": "김하은님의 메세지 내용 8",
+        "font": "Roboto",
+        "createdAt": "2023-04-24T04:50:36Z"
+      }
+    ],
+    "reactionCount": 46,
+    "topReactions": [
+      {
+        "id": 62030,
+        "emoji": "🎉",
+        "count": 15
+      },
+      {
+        "id": 97843,
+        "emoji": "🎉",
+        "count": 10
+      },
+      {
+        "id": 93058,
+        "emoji": "😁",
+        "count": 4
+      }
+    ]
+  },
+  {
+    "id": 87423,
+    "name": "한지민",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2023-07-30T00:10:08Z",
+    "messageCount": 3,
+    "recentMessages": [
+      {
+        "id": 71070,
+        "recipientId": 87423,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/29/200/200",
+        "relationship": "동료",
+        "content": "정우성님의 메세지 내용 2",
+        "font": "Noto Sans",
+        "createdAt": "2023-06-05T10:27:47Z"
+      },
+      {
+        "id": 38287,
+        "recipientId": 87423,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/259/200/200",
+        "relationship": "지인",
+        "content": "한지민님의 메세지 내용 51",
+        "font": "Pretendard",
+        "createdAt": "2023-10-27T10:50:10Z"
+      },
+      {
+        "id": 92441,
+        "recipientId": 87423,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/98/200/200",
+        "relationship": "동료",
+        "content": "박서준님의 메세지 내용 89",
+        "font": "Pretendard",
+        "createdAt": "2023-11-23T15:03:42Z"
+      }
+    ],
+    "reactionCount": 74,
+    "topReactions": [
+      {
+        "id": 48788,
+        "emoji": "🎉",
+        "count": 3
+      },
+      {
+        "id": 40394,
+        "emoji": "🥹",
+        "count": 18
+      },
+      {
+        "id": 22994,
+        "emoji": "😁",
+        "count": 16
+      },
+      {
+        "id": 46587,
+        "emoji": "🎉",
+        "count": 17
+      },
+      {
+        "id": 83614,
+        "emoji": "🥹",
+        "count": 13
+      }
+    ]
+  },
+  {
+    "id": 37498,
+    "name": "박서준",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/37498/600/400",
+    "createdAt": "2023-08-19T22:44:58Z",
+    "messageCount": 6,
+    "recentMessages": [
+      {
+        "id": 7778,
+        "recipientId": 37498,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/202/200/200",
+        "relationship": "가족",
+        "content": "이병헌님의 메세지 내용 24",
+        "font": "Pretendard",
+        "createdAt": "2023-12-27T07:03:22Z"
+      },
+      {
+        "id": 50047,
+        "recipientId": 37498,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/448/200/200",
+        "relationship": "지인",
+        "content": "한지민님의 메세지 내용 34",
+        "font": "Noto Sans",
+        "createdAt": "2023-06-01T01:56:52Z"
+      },
+      {
+        "id": 849,
+        "recipientId": 37498,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/319/200/200",
+        "relationship": "가족",
+        "content": "김하은님의 메세지 내용 99",
+        "font": "Roboto",
+        "createdAt": "2023-04-16T07:26:51Z"
+      }
+    ],
+    "reactionCount": 86,
+    "topReactions": [
+      {
+        "id": 3081,
+        "emoji": "❤️",
+        "count": 15
+      },
+      {
+        "id": 5953,
+        "emoji": "😁",
+        "count": 9
+      },
+      {
+        "id": 28198,
+        "emoji": "😀",
+        "count": 2
+      },
+      {
+        "id": 89135,
+        "emoji": "👍",
+        "count": 5
+      }
+    ]
+  },
+  {
+    "id": 804,
+    "name": "김하은",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/804/600/400",
+    "createdAt": "2023-12-31T06:48:26Z",
+    "messageCount": 2,
+    "recentMessages": [
+      {
+        "id": 92345,
+        "recipientId": 804,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/119/200/200",
+        "relationship": "동료",
+        "content": "최민수님의 메세지 내용 82",
+        "font": "Pretendard",
+        "createdAt": "2023-08-19T15:47:19Z"
+      },
+      {
+        "id": 18005,
+        "recipientId": 804,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/53/200/200",
+        "relationship": "친구",
+        "content": "최민수님의 메세지 내용 96",
+        "font": "Pretendard",
+        "createdAt": "2023-05-22T23:53:08Z"
+      }
+    ],
+    "reactionCount": 44,
+    "topReactions": [
+      {
+        "id": 5603,
+        "emoji": "👍",
+        "count": 5
+      }
+    ]
+  },
+  {
+    "id": 27292,
+    "name": "김하은",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/27292/600/400",
+    "createdAt": "2023-12-02T16:16:54Z",
+    "messageCount": 4,
+    "recentMessages": [
+      {
+        "id": 14570,
+        "recipientId": 27292,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/145/200/200",
+        "relationship": "지인",
+        "content": "이영준님의 메세지 내용 41",
+        "font": "Noto Sans",
+        "createdAt": "2023-05-31T17:54:46Z"
+      },
+      {
+        "id": 73005,
+        "recipientId": 27292,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/471/200/200",
+        "relationship": "동료",
+        "content": "최민수님의 메세지 내용 43",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-11-03T09:06:00Z"
+      },
+      {
+        "id": 67991,
+        "recipientId": 27292,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/499/200/200",
+        "relationship": "지인",
+        "content": "정우성님의 메세지 내용 42",
+        "font": "Pretendard",
+        "createdAt": "2024-02-05T04:43:27Z"
+      }
+    ],
+    "reactionCount": 19,
+    "topReactions": [
+      {
+        "id": 56372,
+        "emoji": "😁",
+        "count": 2
+      },
+      {
+        "id": 27688,
+        "emoji": "😀",
+        "count": 12
+      },
+      {
+        "id": 41479,
+        "emoji": "😁",
+        "count": 9
+      },
+      {
+        "id": 84278,
+        "emoji": "👍",
+        "count": 1
+      },
+      {
+        "id": 10391,
+        "emoji": "❤️",
+        "count": 15
+      },
+      {
+        "id": 47486,
+        "emoji": "👍",
+        "count": 14
+      }
+    ]
+  },
+  {
+    "id": 42364,
+    "name": "송혜교",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/42364/600/400",
+    "createdAt": "2023-10-24T15:14:56Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 62241,
+        "recipientId": 42364,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/165/200/200",
+        "relationship": "친구",
+        "content": "한지민님의 메세지 내용 17",
+        "font": "Roboto",
+        "createdAt": "2023-01-16T13:07:22Z"
+      },
+      {
+        "id": 35391,
+        "recipientId": 42364,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/261/200/200",
+        "relationship": "가족",
+        "content": "박서준님의 메세지 내용 91",
+        "font": "Roboto",
+        "createdAt": "2023-11-27T15:42:27Z"
+      },
+      {
+        "id": 82773,
+        "recipientId": 42364,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/343/200/200",
+        "relationship": "동료",
+        "content": "박서준님의 메세지 내용 31",
+        "font": "Nanum Gothic",
+        "createdAt": "2024-01-31T07:30:06Z"
+      }
+    ],
+    "reactionCount": 51,
+    "topReactions": [
+      {
+        "id": 91006,
+        "emoji": "😁",
+        "count": 7
+      },
+      {
+        "id": 33237,
+        "emoji": "😀",
+        "count": 9
+      },
+      {
+        "id": 53636,
+        "emoji": "🎉",
+        "count": 12
+      },
+      {
+        "id": 15454,
+        "emoji": "😀",
+        "count": 18
+      },
+      {
+        "id": 14384,
+        "emoji": "❤️",
+        "count": 14
+      }
+    ]
+  },
+  {
+    "id": 12700,
+    "name": "이병헌",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2023-08-18T22:43:12Z",
+    "messageCount": 6,
+    "recentMessages": [
+      {
+        "id": 81662,
+        "recipientId": 12700,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/362/200/200",
+        "relationship": "가족",
+        "content": "전지현님의 메세지 내용 94",
+        "font": "Pretendard",
+        "createdAt": "2023-01-25T05:02:39Z"
+      },
+      {
+        "id": 29275,
+        "recipientId": 12700,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/163/200/200",
+        "relationship": "지인",
+        "content": "한지민님의 메세지 내용 32",
+        "font": "Noto Sans",
+        "createdAt": "2023-01-19T15:33:19Z"
+      },
+      {
+        "id": 4746,
+        "recipientId": 12700,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/260/200/200",
+        "relationship": "친구",
+        "content": "이병헌님의 메세지 내용 44",
+        "font": "Noto Sans",
+        "createdAt": "2023-02-17T03:59:23Z"
+      }
+    ],
+    "reactionCount": 74,
+    "topReactions": [
+      {
+        "id": 88984,
+        "emoji": "❤️",
+        "count": 18
+      },
+      {
+        "id": 57596,
+        "emoji": "❤️",
+        "count": 1
+      },
+      {
+        "id": 12377,
+        "emoji": "🥹",
+        "count": 17
+      },
+      {
+        "id": 45146,
+        "emoji": "❤️",
+        "count": 9
+      },
+      {
+        "id": 53052,
+        "emoji": "🥹",
+        "count": 7
+      },
+      {
+        "id": 60303,
+        "emoji": "❤️",
+        "count": 10
+      }
+    ]
+  },
+  {
+    "id": 91444,
+    "name": "송혜교",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/91444/600/400",
+    "createdAt": "2023-06-03T08:08:37Z",
+    "messageCount": 2,
+    "recentMessages": [
+      {
+        "id": 75089,
+        "recipientId": 91444,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/380/200/200",
+        "relationship": "지인",
+        "content": "박서준님의 메세지 내용 22",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-12-14T21:41:57Z"
+      },
+      {
+        "id": 98743,
+        "recipientId": 91444,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/27/200/200",
+        "relationship": "친구",
+        "content": "이영준님의 메세지 내용 74",
+        "font": "Noto Sans",
+        "createdAt": "2023-09-23T04:44:23Z"
+      }
+    ],
+    "reactionCount": 9,
+    "topReactions": [
+      {
+        "id": 5270,
+        "emoji": "🎉",
+        "count": 4
+      },
+      {
+        "id": 42056,
+        "emoji": "🎉",
+        "count": 9
+      },
+      {
+        "id": 79595,
+        "emoji": "❤️",
+        "count": 20
+      },
+      {
+        "id": 49566,
+        "emoji": "😁",
+        "count": 10
+      }
+    ]
+  },
+  {
+    "id": 431,
+    "name": "송혜교",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/431/600/400",
+    "createdAt": "2023-09-19T05:38:16Z",
+    "messageCount": 10,
+    "recentMessages": [
+      {
+        "id": 85796,
+        "recipientId": 431,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/391/200/200",
+        "relationship": "친구",
+        "content": "정우성님의 메세지 내용 89",
+        "font": "Pretendard",
+        "createdAt": "2023-06-30T16:55:54Z"
+      },
+      {
+        "id": 45946,
+        "recipientId": 431,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/231/200/200",
+        "relationship": "가족",
+        "content": "송혜교님의 메세지 내용 22",
+        "font": "Noto Sans",
+        "createdAt": "2023-07-29T17:47:32Z"
+      },
+      {
+        "id": 19138,
+        "recipientId": 431,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/112/200/200",
+        "relationship": "친구",
+        "content": "전지현님의 메세지 내용 98",
+        "font": "Pretendard",
+        "createdAt": "2023-03-09T07:33:56Z"
+      }
+    ],
+    "reactionCount": 53,
+    "topReactions": [
+      {
+        "id": 89292,
+        "emoji": "❤️",
+        "count": 4
+      },
+      {
+        "id": 50557,
+        "emoji": "🥹",
+        "count": 14
+      },
+      {
+        "id": 50390,
+        "emoji": "🎉",
+        "count": 1
+      }
+    ]
+  },
+  {
+    "id": 59201,
+    "name": "한지민",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/59201/600/400",
+    "createdAt": "2023-08-02T10:38:08Z",
+    "messageCount": 10,
+    "recentMessages": [
+      {
+        "id": 92555,
+        "recipientId": 59201,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/65/200/200",
+        "relationship": "친구",
+        "content": "전지현님의 메세지 내용 91",
+        "font": "Roboto",
+        "createdAt": "2023-04-10T02:51:26Z"
+      },
+      {
+        "id": 64459,
+        "recipientId": 59201,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/452/200/200",
+        "relationship": "가족",
+        "content": "전지현님의 메세지 내용 13",
+        "font": "Noto Sans",
+        "createdAt": "2023-11-09T13:15:50Z"
+      },
+      {
+        "id": 48918,
+        "recipientId": 59201,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/45/200/200",
+        "relationship": "지인",
+        "content": "박서준님의 메세지 내용 21",
+        "font": "Roboto",
+        "createdAt": "2023-01-05T13:09:05Z"
+      }
+    ],
+    "reactionCount": 65,
+    "topReactions": [
+      {
+        "id": 79656,
+        "emoji": "🎉",
+        "count": 14
+      }
+    ]
+  },
+  {
+    "id": 6989,
+    "name": "김하은",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/6989/600/400",
+    "createdAt": "2023-04-14T01:33:48Z",
+    "messageCount": 7,
+    "recentMessages": [
+      {
+        "id": 81227,
+        "recipientId": 6989,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/484/200/200",
+        "relationship": "가족",
+        "content": "최민수님의 메세지 내용 56",
+        "font": "Roboto",
+        "createdAt": "2024-01-05T22:51:56Z"
+      },
+      {
+        "id": 15361,
+        "recipientId": 6989,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/281/200/200",
+        "relationship": "지인",
+        "content": "현빈님의 메세지 내용 46",
+        "font": "Noto Sans",
+        "createdAt": "2023-06-19T05:28:03Z"
+      },
+      {
+        "id": 98203,
+        "recipientId": 6989,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/28/200/200",
+        "relationship": "친구",
+        "content": "정우성님의 메세지 내용 88",
+        "font": "Pretendard",
+        "createdAt": "2023-12-18T08:50:50Z"
+      }
+    ],
+    "reactionCount": 41,
+    "topReactions": [
+      {
+        "id": 90464,
+        "emoji": "😀",
+        "count": 14
+      },
+      {
+        "id": 30005,
+        "emoji": "😀",
+        "count": 10
+      }
+    ]
+  },
+  {
+    "id": 56031,
+    "name": "전지현",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/56031/600/400",
+    "createdAt": "2023-01-03T23:21:51Z",
+    "messageCount": 5,
+    "recentMessages": [
+      {
+        "id": 47661,
+        "recipientId": 56031,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/395/200/200",
+        "relationship": "동료",
+        "content": "이병헌님의 메세지 내용 62",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-08-20T17:27:35Z"
+      },
+      {
+        "id": 20252,
+        "recipientId": 56031,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/49/200/200",
+        "relationship": "동료",
+        "content": "현빈님의 메세지 내용 63",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-07-10T22:36:06Z"
+      },
+      {
+        "id": 23385,
+        "recipientId": 56031,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/498/200/200",
+        "relationship": "가족",
+        "content": "송혜교님의 메세지 내용 11",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-06-21T11:14:02Z"
+      }
+    ],
+    "reactionCount": 83,
+    "topReactions": [
+      {
+        "id": 33533,
+        "emoji": "❤️",
+        "count": 11
+      },
+      {
+        "id": 51483,
+        "emoji": "🥹",
+        "count": 16
+      }
+    ]
+  },
+  {
+    "id": 2331,
+    "name": "송혜교",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/2331/600/400",
+    "createdAt": "2023-12-17T01:45:14Z",
+    "messageCount": 9,
+    "recentMessages": [
+      {
+        "id": 66942,
+        "recipientId": 2331,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/245/200/200",
+        "relationship": "가족",
+        "content": "전지현님의 메세지 내용 89",
+        "font": "Pretendard",
+        "createdAt": "2023-08-18T18:11:01Z"
+      },
+      {
+        "id": 42191,
+        "recipientId": 2331,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/336/200/200",
+        "relationship": "가족",
+        "content": "최민수님의 메세지 내용 55",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-02-06T06:21:56Z"
+      },
+      {
+        "id": 8612,
+        "recipientId": 2331,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/120/200/200",
+        "relationship": "동료",
+        "content": "김하은님의 메세지 내용 40",
+        "font": "Noto Sans",
+        "createdAt": "2023-05-16T19:20:19Z"
+      }
+    ],
+    "reactionCount": 61,
+    "topReactions": [
+      {
+        "id": 76710,
+        "emoji": "👍",
+        "count": 5
+      }
+    ]
+  },
+  {
+    "id": 80397,
+    "name": "최민수",
+    "backgroundColor": "green",
+    "backgroundImageURL": null,
+    "createdAt": "2023-11-20T05:03:59Z",
+    "messageCount": 2,
+    "recentMessages": [
+      {
+        "id": 51404,
+        "recipientId": 80397,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/222/200/200",
+        "relationship": "지인",
+        "content": "송혜교님의 메세지 내용 47",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-11-10T08:33:06Z"
+      },
+      {
+        "id": 3634,
+        "recipientId": 80397,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/430/200/200",
+        "relationship": "동료",
+        "content": "김하은님의 메세지 내용 63",
+        "font": "Noto Sans",
+        "createdAt": "2023-04-27T11:10:26Z"
+      }
+    ],
+    "reactionCount": 97,
+    "topReactions": [
+      {
+        "id": 82751,
+        "emoji": "🥹",
+        "count": 7
+      },
+      {
+        "id": 27780,
+        "emoji": "🥹",
+        "count": 11
+      },
+      {
+        "id": 11937,
+        "emoji": "❤️",
+        "count": 15
+      },
+      {
+        "id": 35875,
+        "emoji": "❤️",
+        "count": 9
+      },
+      {
+        "id": 93134,
+        "emoji": "😀",
+        "count": 6
+      }
+    ]
+  },
+  {
+    "id": 92514,
+    "name": "정우성",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-10-03T05:42:45Z",
+    "messageCount": 9,
+    "recentMessages": [
+      {
+        "id": 17969,
+        "recipientId": 92514,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/229/200/200",
+        "relationship": "동료",
+        "content": "최민수님의 메세지 내용 59",
+        "font": "Pretendard",
+        "createdAt": "2023-07-25T08:20:39Z"
+      },
+      {
+        "id": 27640,
+        "recipientId": 92514,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/12/200/200",
+        "relationship": "지인",
+        "content": "한지민님의 메세지 내용 90",
+        "font": "Noto Sans",
+        "createdAt": "2023-08-09T19:30:02Z"
+      },
+      {
+        "id": 51718,
+        "recipientId": 92514,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/196/200/200",
+        "relationship": "가족",
+        "content": "전지현님의 메세지 내용 50",
+        "font": "Noto Sans",
+        "createdAt": "2023-09-21T04:00:24Z"
+      }
+    ],
+    "reactionCount": 48,
+    "topReactions": [
+      {
+        "id": 33044,
+        "emoji": "🥹",
+        "count": 18
+      },
+      {
+        "id": 77894,
+        "emoji": "😁",
+        "count": 4
+      },
+      {
+        "id": 97021,
+        "emoji": "🎉",
+        "count": 17
+      },
+      {
+        "id": 94868,
+        "emoji": "🥹",
+        "count": 3
+      }
+    ]
+  },
+  {
+    "id": 91659,
+    "name": "박서준",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/91659/600/400",
+    "createdAt": "2023-02-05T05:14:29Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 86637,
+        "recipientId": 91659,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/95/200/200",
+        "relationship": "동료",
+        "content": "최민수님의 메세지 내용 53",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-12-23T14:34:42Z"
+      },
+      {
+        "id": 43583,
+        "recipientId": 91659,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/400/200/200",
+        "relationship": "지인",
+        "content": "김하은님의 메세지 내용 31",
+        "font": "Pretendard",
+        "createdAt": "2023-06-03T00:26:24Z"
+      },
+      {
+        "id": 32047,
+        "recipientId": 91659,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/127/200/200",
+        "relationship": "가족",
+        "content": "한지민님의 메세지 내용 65",
+        "font": "Pretendard",
+        "createdAt": "2023-12-30T16:06:15Z"
+      }
+    ],
+    "reactionCount": 13,
+    "topReactions": [
+      {
+        "id": 81498,
+        "emoji": "❤️",
+        "count": 10
+      },
+      {
+        "id": 39236,
+        "emoji": "❤️",
+        "count": 17
+      }
+    ]
+  },
+  {
+    "id": 52526,
+    "name": "전지현",
+    "backgroundColor": "green",
+    "backgroundImageURL": null,
+    "createdAt": "2023-12-06T09:42:54Z",
+    "messageCount": 3,
+    "recentMessages": [
+      {
+        "id": 95226,
+        "recipientId": 52526,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/364/200/200",
+        "relationship": "가족",
+        "content": "최민수님의 메세지 내용 12",
+        "font": "Roboto",
+        "createdAt": "2023-03-22T23:13:59Z"
+      },
+      {
+        "id": 5308,
+        "recipientId": 52526,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/293/200/200",
+        "relationship": "친구",
+        "content": "박서준님의 메세지 내용 53",
+        "font": "Roboto",
+        "createdAt": "2023-07-05T04:02:56Z"
+      },
+      {
+        "id": 22581,
+        "recipientId": 52526,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/471/200/200",
+        "relationship": "지인",
+        "content": "한지민님의 메세지 내용 100",
+        "font": "Pretendard",
+        "createdAt": "2023-07-11T08:25:24Z"
+      }
+    ],
+    "reactionCount": 57,
+    "topReactions": [
+      {
+        "id": 5184,
+        "emoji": "👍",
+        "count": 18
+      },
+      {
+        "id": 31068,
+        "emoji": "😁",
+        "count": 8
+      },
+      {
+        "id": 87339,
+        "emoji": "👍",
+        "count": 2
+      },
+      {
+        "id": 79179,
+        "emoji": "❤️",
+        "count": 15
+      },
+      {
+        "id": 2076,
+        "emoji": "😁",
+        "count": 9
+      },
+      {
+        "id": 9962,
+        "emoji": "👍",
+        "count": 15
+      }
+    ]
+  },
+  {
+    "id": 66246,
+    "name": "박서준",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/66246/600/400",
+    "createdAt": "2023-06-05T11:15:08Z",
+    "messageCount": 6,
+    "recentMessages": [
+      {
+        "id": 67335,
+        "recipientId": 66246,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/155/200/200",
+        "relationship": "지인",
+        "content": "최민수님의 메세지 내용 92",
+        "font": "Pretendard",
+        "createdAt": "2023-11-13T18:00:50Z"
+      },
+      {
+        "id": 97868,
+        "recipientId": 66246,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/163/200/200",
+        "relationship": "가족",
+        "content": "송혜교님의 메세지 내용 8",
+        "font": "Nanum Gothic",
+        "createdAt": "2024-01-30T05:20:18Z"
+      },
+      {
+        "id": 36892,
+        "recipientId": 66246,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/204/200/200",
+        "relationship": "친구",
+        "content": "송혜교님의 메세지 내용 51",
+        "font": "Noto Sans",
+        "createdAt": "2023-04-03T14:58:25Z"
+      }
+    ],
+    "reactionCount": 87,
+    "topReactions": [
+      {
+        "id": 87641,
+        "emoji": "😁",
+        "count": 12
+      },
+      {
+        "id": 89470,
+        "emoji": "😀",
+        "count": 4
+      },
+      {
+        "id": 40031,
+        "emoji": "❤️",
+        "count": 1
+      },
+      {
+        "id": 42953,
+        "emoji": "😁",
+        "count": 18
+      }
+    ]
+  },
+  {
+    "id": 78492,
+    "name": "현빈",
+    "backgroundColor": "blue",
+    "backgroundImageURL": null,
+    "createdAt": "2023-06-27T06:54:39Z",
+    "messageCount": 5,
+    "recentMessages": [
+      {
+        "id": 51872,
+        "recipientId": 78492,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/149/200/200",
+        "relationship": "지인",
+        "content": "전지현님의 메세지 내용 14",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-08-29T19:08:59Z"
+      },
+      {
+        "id": 55542,
+        "recipientId": 78492,
+        "sender": "전지현",
+        "profileImageURL": "https://picsum.photos/id/283/200/200",
+        "relationship": "지인",
+        "content": "전지현님의 메세지 내용 79",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-01-14T20:52:51Z"
+      },
+      {
+        "id": 93850,
+        "recipientId": 78492,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/441/200/200",
+        "relationship": "지인",
+        "content": "송혜교님의 메세지 내용 80",
+        "font": "Pretendard",
+        "createdAt": "2023-11-01T00:19:15Z"
+      }
+    ],
+    "reactionCount": 55,
+    "topReactions": [
+      {
+        "id": 71312,
+        "emoji": "❤️",
+        "count": 1
+      }
+    ]
+  },
+  {
+    "id": 82777,
+    "name": "현빈",
+    "backgroundColor": "blue",
+    "backgroundImageURL": null,
+    "createdAt": "2023-09-15T12:08:04Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 87777,
+        "recipientId": 82777,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/233/200/200",
+        "relationship": "지인",
+        "content": "현빈님의 메세지 내용 6",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-06-02T07:12:19Z"
+      },
+      {
+        "id": 80014,
+        "recipientId": 82777,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/243/200/200",
+        "relationship": "지인",
+        "content": "이영준님의 메세지 내용 12",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-03-29T10:02:35Z"
+      },
+      {
+        "id": 70414,
+        "recipientId": 82777,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/179/200/200",
+        "relationship": "친구",
+        "content": "송혜교님의 메세지 내용 38",
+        "font": "Noto Sans",
+        "createdAt": "2023-10-05T10:33:01Z"
+      }
+    ],
+    "reactionCount": 34,
+    "topReactions": [
+      {
+        "id": 4256,
+        "emoji": "👍",
+        "count": 4
+      },
+      {
+        "id": 89759,
+        "emoji": "❤️",
+        "count": 3
+      }
+    ]
+  },
+  {
+    "id": 16044,
+    "name": "전지현",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2023-05-20T07:28:44Z",
+    "messageCount": 1,
+    "recentMessages": [
+      {
+        "id": 88553,
+        "recipientId": 16044,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/109/200/200",
+        "relationship": "가족",
+        "content": "최민수님의 메세지 내용 76",
+        "font": "Pretendard",
+        "createdAt": "2023-08-03T22:59:16Z"
+      }
+    ],
+    "reactionCount": 40,
+    "topReactions": [
+      {
+        "id": 93310,
+        "emoji": "😁",
+        "count": 4
+      },
+      {
+        "id": 37249,
+        "emoji": "😁",
+        "count": 5
+      },
+      {
+        "id": 73269,
+        "emoji": "🥹",
+        "count": 7
+      }
+    ]
+  },
+  {
+    "id": 42617,
+    "name": "정우성",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2023-09-04T03:21:42Z",
+    "messageCount": 6,
+    "recentMessages": [
+      {
+        "id": 36095,
+        "recipientId": 42617,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/119/200/200",
+        "relationship": "동료",
+        "content": "박서준님의 메세지 내용 8",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-03-20T16:47:37Z"
+      },
+      {
+        "id": 79006,
+        "recipientId": 42617,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/58/200/200",
+        "relationship": "친구",
+        "content": "김하은님의 메세지 내용 81",
+        "font": "Roboto",
+        "createdAt": "2023-05-27T14:29:42Z"
+      },
+      {
+        "id": 54211,
+        "recipientId": 42617,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/57/200/200",
+        "relationship": "지인",
+        "content": "현빈님의 메세지 내용 70",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-05-14T01:15:48Z"
+      }
+    ],
+    "reactionCount": 12,
+    "topReactions": [
+      {
+        "id": 66681,
+        "emoji": "🥹",
+        "count": 8
+      },
+      {
+        "id": 67854,
+        "emoji": "😁",
+        "count": 15
+      },
+      {
+        "id": 94387,
+        "emoji": "❤️",
+        "count": 16
+      },
+      {
+        "id": 94338,
+        "emoji": "🎉",
+        "count": 20
+      },
+      {
+        "id": 59665,
+        "emoji": "🎉",
+        "count": 8
+      }
+    ]
+  },
+  {
+    "id": 63381,
+    "name": "최민수",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/seed/63381/600/400",
+    "createdAt": "2023-05-05T23:49:25Z",
+    "messageCount": 5,
+    "recentMessages": [
+      {
+        "id": 56206,
+        "recipientId": 63381,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/73/200/200",
+        "relationship": "친구",
+        "content": "최민수님의 메세지 내용 80",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-09-19T13:55:51Z"
+      },
+      {
+        "id": 15343,
+        "recipientId": 63381,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/1/200/200",
+        "relationship": "가족",
+        "content": "정우성님의 메세지 내용 30",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-12-09T14:00:31Z"
+      },
+      {
+        "id": 64540,
+        "recipientId": 63381,
+        "sender": "송혜교",
+        "profileImageURL": "https://picsum.photos/id/486/200/200",
+        "relationship": "동료",
+        "content": "송혜교님의 메세지 내용 92",
+        "font": "Noto Sans",
+        "createdAt": "2023-04-10T11:58:05Z"
+      }
+    ],
+    "reactionCount": 26,
+    "topReactions": [
+      {
+        "id": 63913,
+        "emoji": "😀",
+        "count": 8
+      },
+      {
+        "id": 82488,
+        "emoji": "🎉",
+        "count": 6
+      },
+      {
+        "id": 38729,
+        "emoji": "👍",
+        "count": 3
+      },
+      {
+        "id": 79770,
+        "emoji": "❤️",
+        "count": 16
+      },
+      {
+        "id": 75631,
+        "emoji": "🎉",
+        "count": 5
+      }
+    ]
+  },
+  {
+    "id": 25814,
+    "name": "송혜교",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/seed/25814/600/400",
+    "createdAt": "2023-09-02T07:06:25Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 18455,
+        "recipientId": 25814,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/361/200/200",
+        "relationship": "동료",
+        "content": "박서준님의 메세지 내용 49",
+        "font": "Noto Sans",
+        "createdAt": "2023-02-12T08:14:35Z"
+      },
+      {
+        "id": 45626,
+        "recipientId": 25814,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/476/200/200",
+        "relationship": "동료",
+        "content": "최민수님의 메세지 내용 18",
+        "font": "Pretendard",
+        "createdAt": "2023-09-04T23:48:15Z"
+      },
+      {
+        "id": 71644,
+        "recipientId": 25814,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/485/200/200",
+        "relationship": "친구",
+        "content": "현빈님의 메세지 내용 59",
+        "font": "Roboto",
+        "createdAt": "2023-08-12T05:15:13Z"
+      }
+    ],
+    "reactionCount": 45,
+    "topReactions": [
+      {
+        "id": 86657,
+        "emoji": "🥹",
+        "count": 10
+      },
+      {
+        "id": 6702,
+        "emoji": "🎉",
+        "count": 11
+      },
+      {
+        "id": 64387,
+        "emoji": "🥹",
+        "count": 7
+      },
+      {
+        "id": 16189,
+        "emoji": "😀",
+        "count": 11
+      },
+      {
+        "id": 58652,
+        "emoji": "🎉",
+        "count": 2
+      },
+      {
+        "id": 67118,
+        "emoji": "🥹",
+        "count": 5
+      }
+    ]
+  },
+  {
+    "id": 85652,
+    "name": "현빈",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-09-30T18:53:27Z",
+    "messageCount": 7,
+    "recentMessages": [
+      {
+        "id": 13934,
+        "recipientId": 85652,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/456/200/200",
+        "relationship": "친구",
+        "content": "한지민님의 메세지 내용 43",
+        "font": "Pretendard",
+        "createdAt": "2023-11-22T11:38:51Z"
+      },
+      {
+        "id": 5599,
+        "recipientId": 85652,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/26/200/200",
+        "relationship": "지인",
+        "content": "정우성님의 메세지 내용 90",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-11-21T01:23:07Z"
+      },
+      {
+        "id": 78185,
+        "recipientId": 85652,
+        "sender": "이영준",
+        "profileImageURL": "https://picsum.photos/id/193/200/200",
+        "relationship": "가족",
+        "content": "이영준님의 메세지 내용 14",
+        "font": "Nanum Gothic",
+        "createdAt": "2024-01-16T07:51:56Z"
+      }
+    ],
+    "reactionCount": 15,
+    "topReactions": [
+      {
+        "id": 40353,
+        "emoji": "🥹",
+        "count": 19
+      },
+      {
+        "id": 25637,
+        "emoji": "👍",
+        "count": 17
+      },
+      {
+        "id": 34226,
+        "emoji": "🥹",
+        "count": 4
+      },
+      {
+        "id": 14495,
+        "emoji": "👍",
+        "count": 14
+      },
+      {
+        "id": 96566,
+        "emoji": "❤️",
+        "count": 3
+      },
+      {
+        "id": 2409,
+        "emoji": "🎉",
+        "count": 10
+      }
+    ]
+  },
+  {
+    "id": 70835,
+    "name": "이영준",
+    "backgroundColor": "beige",
+    "backgroundImageURL": null,
+    "createdAt": "2023-04-17T15:50:50Z",
+    "messageCount": 9,
+    "recentMessages": [
+      {
+        "id": 32521,
+        "recipientId": 70835,
+        "sender": "김하은",
+        "profileImageURL": "https://picsum.photos/id/475/200/200",
+        "relationship": "지인",
+        "content": "김하은님의 메세지 내용 24",
+        "font": "Pretendard",
+        "createdAt": "2023-09-29T00:00:45Z"
+      },
+      {
+        "id": 77740,
+        "recipientId": 70835,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/288/200/200",
+        "relationship": "지인",
+        "content": "박서준님의 메세지 내용 84",
+        "font": "Roboto",
+        "createdAt": "2023-02-22T09:49:22Z"
+      },
+      {
+        "id": 95524,
+        "recipientId": 70835,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/375/200/200",
+        "relationship": "동료",
+        "content": "한지민님의 메세지 내용 91",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-04-04T03:33:36Z"
+      }
+    ],
+    "reactionCount": 73,
+    "topReactions": [
+      {
+        "id": 83819,
+        "emoji": "😁",
+        "count": 15
+      },
+      {
+        "id": 91850,
+        "emoji": "🥹",
+        "count": 2
+      }
+    ]
+  },
+  {
+    "id": 77967,
+    "name": "김하은",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/seed/77967/600/400",
+    "createdAt": "2023-01-25T15:36:52Z",
+    "messageCount": 5,
+    "recentMessages": [
+      {
+        "id": 58327,
+        "recipientId": 77967,
+        "sender": "최민수",
+        "profileImageURL": "https://picsum.photos/id/333/200/200",
+        "relationship": "친구",
+        "content": "최민수님의 메세지 내용 39",
+        "font": "Pretendard",
+        "createdAt": "2023-06-14T02:06:26Z"
+      },
+      {
+        "id": 8140,
+        "recipientId": 77967,
+        "sender": "현빈",
+        "profileImageURL": "https://picsum.photos/id/320/200/200",
+        "relationship": "동료",
+        "content": "현빈님의 메세지 내용 17",
+        "font": "Pretendard",
+        "createdAt": "2023-03-29T03:09:31Z"
+      },
+      {
+        "id": 99412,
+        "recipientId": 77967,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/301/200/200",
+        "relationship": "동료",
+        "content": "한지민님의 메세지 내용 49",
+        "font": "Pretendard",
+        "createdAt": "2023-09-30T06:21:13Z"
+      }
+    ],
+    "reactionCount": 12,
+    "topReactions": [
+      {
+        "id": 14335,
+        "emoji": "❤️",
+        "count": 10
+      },
+      {
+        "id": 37620,
+        "emoji": "😁",
+        "count": 18
+      },
+      {
+        "id": 35030,
+        "emoji": "😁",
+        "count": 18
+      }
+    ]
+  },
+  {
+    "id": 31249,
+    "name": "이병헌",
+    "backgroundColor": "blue",
+    "backgroundImageURL": null,
+    "createdAt": "2023-05-16T17:41:45Z",
+    "messageCount": 2,
+    "recentMessages": [
+      {
+        "id": 77297,
+        "recipientId": 31249,
+        "sender": "정우성",
+        "profileImageURL": "https://picsum.photos/id/356/200/200",
+        "relationship": "동료",
+        "content": "정우성님의 메세지 내용 30",
+        "font": "Roboto",
+        "createdAt": "2023-10-09T19:45:25Z"
+      },
+      {
+        "id": 54855,
+        "recipientId": 31249,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/188/200/200",
+        "relationship": "지인",
+        "content": "이병헌님의 메세지 내용 84",
+        "font": "Pretendard",
+        "createdAt": "2023-07-01T14:34:04Z"
+      }
+    ],
+    "reactionCount": 87,
+    "topReactions": [
+      {
+        "id": 64819,
+        "emoji": "😀",
+        "count": 16
+      },
+      {
+        "id": 14849,
+        "emoji": "😀",
+        "count": 4
+      },
+      {
+        "id": 30100,
+        "emoji": "🎉",
+        "count": 15
+      }
+    ]
+  },
+  {
+    "id": 87008,
+    "name": "이병헌",
+    "backgroundColor": "purple",
+    "backgroundImageURL": null,
+    "createdAt": "2023-05-31T18:24:49Z",
+    "messageCount": 8,
+    "recentMessages": [
+      {
+        "id": 2572,
+        "recipientId": 87008,
+        "sender": "한지민",
+        "profileImageURL": "https://picsum.photos/id/379/200/200",
+        "relationship": "친구",
+        "content": "한지민님의 메세지 내용 9",
+        "font": "Roboto",
+        "createdAt": "2023-05-01T19:29:33Z"
+      },
+      {
+        "id": 29069,
+        "recipientId": 87008,
+        "sender": "이병헌",
+        "profileImageURL": "https://picsum.photos/id/25/200/200",
+        "relationship": "지인",
+        "content": "이병헌님의 메세지 내용 19",
+        "font": "Roboto",
+        "createdAt": "2024-01-14T03:59:30Z"
+      },
+      {
+        "id": 33287,
+        "recipientId": 87008,
+        "sender": "박서준",
+        "profileImageURL": "https://picsum.photos/id/71/200/200",
+        "relationship": "친구",
+        "content": "박서준님의 메세지 내용 61",
+        "font": "Nanum Gothic",
+        "createdAt": "2023-08-09T16:33:57Z"
+      }
+    ],
+    "reactionCount": 42,
+    "topReactions": [
+      {
+        "id": 86769,
+        "emoji": "❤️",
+        "count": 10
+      },
+      {
+        "id": 17942,
+        "emoji": "👍",
+        "count": 8
+      },
+      {
+        "id": 88772,
+        "emoji": "😀",
+        "count": 5
+      },
+      {
+        "id": 69231,
+        "emoji": "👍",
+        "count": 15
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## 📝 작업 내용

> [#43] rolling paper list 페이지, 내부 컴포넌트 분리 및 데이터 정렬

## 📷 스크린샷 (선택)

> <img width="244" height="250" alt="image" src="https://github.com/user-attachments/assets/f5ccc773-3129-4e33-ab63-763fd9392325" />
컴포넌트 분리

## 🧐 해결해야 하는 문제 (선택)

> <img width="251" height="165" alt="image" src="https://github.com/user-attachments/assets/6d0a918c-eb0b-43f4-acdf-54453f83a1f0" />
이미지 로딩느린문제때문에 캐시하면된다길래 일단쓰긴했는데 어느정도 효과는 있지만 여전히 너무 느리네요.
일단 다른방법 더 찾아보겠습니다.

