### PR TITLE
[#50] Vercel 배포

### DIFF
--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -1,0 +1,31 @@
+name: Synchronize to forked repo
+on:
+  push:
+    branches:
+      - develop
+jobs:
+  sync:
+    name: Sync forked repo
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.AUTO_ACTIONS }}
+          fetch-depth: 0
+          ref: develop
+
+      - name: Add remote-url
+        run: |
+          git remote add forked-repo https://cskime:${{ secrets.AUTO_ACTIONS }}@github.com/cskime/rolling
+          git config user.name cskime
+          git config user.email ${{ secrets.EMAIL }}
+
+      - name: Push changes to forked-repo
+        run: |
+          git push -f forked-repo develop
+
+      - name: Clean up
+        run: |
+          git remote remove forked-repo

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
## 📝 작업 내용

- Vercel에 SPA 배포 시 경로 문제를 해결하기 위해 `vercel.json`에서 root redirect를 설정합니다.
- Vercel의 organization repository에 대한 유료 plan을 우회하여 무료 배포하는 GitHub Actions workflow를 작성합니다.

## 👀 새로 알게 된 내용 (선택)

- 일반적으로 브라우저에서 어떤 경로(URL)에 접근하면 웹 서버에 해당 path에 있는 `index.html` 파일을 찾아서 응답으로 보내줍니다.
- 그런데, SPA는 root 경로에 `index.html` 하나만 가지고 있고 이것을 번들링된 JavaScript 파일을 통해 요소들을 추가/삭제하며 화면을 그립니다. React 웹 앱에서 특정 경로로 접근하면 웹 서버에 해당 경로의 HTML 파일을 요청하는 대신 React Router 등을 사용해서 path 별로 미리 정의해 둔 component를 바꿔서 rendering 합니다.
- 그래서, Vercel 같은 정적 웹사이트 배포 서비스에 React로 만든 SPA 프로젝트를 배포한 뒤 root(`/`) 이외의 경로로 접근하면 404 error가 발생합니다. React 웹 앱은 root에 단 하나의 `index.html`만 갖기 때문입니다.
- 이 문제를 해결하는 방법은 접근하려는 모든 경로를 root(`/`)로 redirect 시키는 것입니다. Vercel은 root에 `vercel.json` 파일을 만들고 아래와 같이 모든 path에 대한 요청을 root(`/`)로 redirect 시키도록 작성합니다.
  ```json
  {
    "rewrites": [{ "source": "/(.*)", "destination": "/" }]
  }
  ```

## 💬 리뷰어에게 남길 말 (선택)

- 정상 동작하는지 테스트하기 위해 PR이 여러 번 생성 및 merge 될 수 있습니다.
