### PR TITLE
[#52] API 연동 (1)

### DIFF
--- a/src/api/axios-instance.js
+++ b/src/api/axios-instance.js
@@ -1,9 +1,0 @@
-import axios from "axios";
-
-const axiosInstance = axios.create({
-  baseURL: "https://rolling-api.vercel.app/",
-  timeout: 5000,
-  headers: { "Content-Type": "application/json" },
-});
-
-export default axiosInstance;

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -1,0 +1,15 @@
+import axios from "axios";
+
+const timeout = 5000;
+
+const baseClient = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL,
+  timeout,
+});
+
+const apiClient = axios.create({
+  baseURL: `${import.meta.env.VITE_API_BASE_URL}/18-3`,
+  timeout,
+});
+
+export { apiClient, baseClient };

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -8,6 +8,7 @@ import MessagePage from "./pages/message-list";
 import MessagesPage from "./pages/messages-page";
 import SendMessagePage from "./pages/send-message-page";
 import TestPage from "./pages/test-page";
+import TestApiPage from "./tests/test-api-page";
 
 function Provider({ children }) {
   return <PortalProvider>{children}</PortalProvider>;
@@ -57,6 +58,7 @@ function App() {
             </Route>
           </Route>
           <Route path="/test-components" element={<TestPage />} />
+          <Route path="/test-api" element={<TestApiPage />} />
           <Route path="/list" element={<MessagePage />} />
         </Routes>
       </BrowserRouter>

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -7,8 +7,8 @@ import MainPage from "./pages/main-page";
 import MessagePage from "./pages/message-list";
 import MessagesPage from "./pages/messages-page";
 import SendMessagePage from "./pages/send-message-page";
-import TestPage from "./pages/test-page";
 import TestApiPage from "./tests/test-api-page";
+import TestComponentsPage from "./tests/test-components-page";
 
 function Provider({ children }) {
   return <PortalProvider>{children}</PortalProvider>;
@@ -57,7 +57,7 @@ function App() {
               />
             </Route>
           </Route>
-          <Route path="/test-components" element={<TestPage />} />
+          <Route path="/test-components" element={<TestComponentsPage />} />
           <Route path="/test-api" element={<TestApiPage />} />
           <Route path="/list" element={<MessagePage />} />
         </Routes>

--- a/src/pages/message-list.jsx
+++ b/src/pages/message-list.jsx
@@ -1,15 +1,9 @@
 import ArrowButton from "../components/button/arrow-button";
 import ARROW_BUTTON_DIRECTION from "../components/button/arrow-button-direction";
-import {
-  OutlinedButton,
-  PrimaryButton,
-  SecondaryButton,
-} from "../components/button/button";
+import { PrimaryButton } from "../components/button/button";
 import BUTTON_SIZE from "../components/button/button-size";
-import ToggleButton from "../components/button/toggle-button";
 
-import React, { useEffect, useState } from "react";
-import axiosInstance from "../api/axios-instance";
+import { useEffect, useState } from "react";
 import styled from "styled-components";
 
 /* styled components */

--- a/src/tests/test-api-page.jsx
+++ b/src/tests/test-api-page.jsx
@@ -210,10 +210,6 @@ function TestApiPage() {
   const handleCreateReactionsClick = async () => {
     const recipientId = prompt("추가할 recipient id", "");
     await createReactions({ recipientId });
-
-    const reactions = await getAllReactions({ recipientId });
-    setReactions(reactions);
-
     updateRecipients();
   };
 

--- a/src/tests/test-api-page.jsx
+++ b/src/tests/test-api-page.jsx
@@ -1,0 +1,294 @@
+import { useCallback, useEffect, useState } from "react";
+import styled from "styled-components";
+import { PrimaryButton } from "../components/button/button";
+import BUTTON_SIZE from "../components/button/button-size";
+import Colors from "../components/color/colors";
+import {
+  createMessages,
+  createReactions,
+  createRecipients,
+  deleteAllMessages,
+  deleteAllRecipients,
+  getAllMessages,
+  getAllReactions,
+  getAllRecipients,
+} from "./test-api";
+
+const Page = styled.div`
+  margin: 24px;
+`;
+
+const Row = styled.div`
+  display: flex;
+  gap: 16px;
+`;
+
+const Column = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+
+const Table = styled.table`
+  border: 1px solid black;
+  border-collapse: collapse;
+  text-align: center;
+`;
+
+const TableHeader = styled.thead`
+  font-weight: 700;
+  background-color: ${Colors.gray(100)};
+`;
+
+const TableRow = styled.tr``;
+
+const TableBody = styled.tbody`
+  & > tr:hover {
+    cursor: pointer;
+    background-color: ${Colors.gray(100)};
+  }
+`;
+
+const TableData = styled.td`
+  border: 1px solid black;
+  border-collapse: collapse;
+  padding: 4px 12px;
+`;
+
+function RecipientsTable({ recipients, onClick }) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableData>id</TableData>
+          <TableData>name</TableData>
+          <TableData>backgroundColor</TableData>
+          <TableData>backgroundImageURL</TableData>
+          <TableData>messageCount</TableData>
+          <TableData>reactionCount</TableData>
+          <TableData>createdAt</TableData>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {recipients.map((recipient) => (
+          <TableRow
+            key={recipient.id}
+            onClick={onClick ? () => onClick(recipient) : undefined}
+          >
+            <TableData>{recipient.id}</TableData>
+            <TableData>{recipient.name}</TableData>
+            <TableData>{recipient.backgroundColor}</TableData>
+            <TableData>{recipient.backgroundImageURL}</TableData>
+            <TableData>{recipient.messageCount}</TableData>
+            <TableData>{recipient.reactionCount}</TableData>
+            <TableData>{recipient.createdAt}</TableData>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+function MessagesTable({ messages }) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableData>id</TableData>
+          <TableData>recipientId</TableData>
+          <TableData>sender</TableData>
+          <TableData>profileImageURL</TableData>
+          <TableData>relationship</TableData>
+          <TableData>content</TableData>
+          <TableData>font</TableData>
+          <TableData>createdAt</TableData>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {messages.map((message) => (
+          <TableRow key={message.id}>
+            <TableData>{message.id}</TableData>
+            <TableData>{message.recipientId}</TableData>
+            <TableData>{message.sender}</TableData>
+            <TableData>{message.profileImageURL}</TableData>
+            <TableData>{message.relationship}</TableData>
+            <TableData>{message.content}</TableData>
+            <TableData>{message.font}</TableData>
+            <TableData>{message.createdAt}</TableData>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+function ReactionsTable({ reactions }) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableData>id</TableData>
+          <TableData>emoji</TableData>
+          <TableData>count</TableData>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {reactions.map((reaction) => (
+          <TableRow key={reaction.id}>
+            <TableData>{reaction.id}</TableData>
+            <TableData>{reaction.emoji}</TableData>
+            <TableData>{reaction.count}</TableData>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+function TestApiPage() {
+  const [recipients, setRecipients] = useState([]);
+  const [messages, setMessages] = useState([]);
+  const [reactions, setReactions] = useState([]);
+  const [selectedRecipient, setSelectedRecipient] = useState(null);
+
+  const buttonSize = BUTTON_SIZE.medium;
+
+  const updateRecipients = useCallback(async () => {
+    const recipients = await getAllRecipients();
+    setRecipients(recipients);
+  }, []);
+
+  /* Recipients */
+
+  const handleCreateRecipientsClick = async () => {
+    await createRecipients();
+    updateRecipients();
+  };
+
+  const handleDeleteRecipientsClick = async () => {
+    await deleteAllRecipients(recipients);
+    setRecipients([]);
+    setMessages([]);
+    setReactions([]);
+    setSelectedRecipient(null);
+  };
+
+  const handleRecipientClick = async (recipient) => {
+    setSelectedRecipient(recipient);
+
+    const messages = await getAllMessages({ recipientId: recipient.id });
+    setMessages(messages);
+
+    const reactions = await getAllReactions({ recipientId: recipient.id });
+    setReactions(reactions);
+  };
+
+  /* Messages */
+
+  const handleCreateMessagesClick = async () => {
+    const recipientId = prompt("추가할 recipient id", "");
+    await createMessages({ recipientId });
+    updateRecipients();
+  };
+
+  const handleDeleteMessagesClick = async () => {
+    if (messages.length > 0) {
+      await deleteAllMessages(messages);
+      setMessages([]);
+    } else {
+      const recipientId = prompt("삭제할 recipient id", "");
+      const messages = await getAllMessages({ recipientId });
+      await deleteAllMessages(messages);
+      setMessages([]);
+    }
+
+    updateRecipients();
+  };
+
+  /* Reactions */
+
+  const handleCreateReactionsClick = async () => {
+    const recipientId = prompt("추가할 recipient id", "");
+    await createReactions({ recipientId });
+
+    const reactions = await getAllReactions({ recipientId });
+    setReactions(reactions);
+
+    updateRecipients();
+  };
+
+  useEffect(() => {
+    updateRecipients();
+  }, [updateRecipients]);
+
+  return (
+    <Page>
+      <Column>
+        <Row>
+          <PrimaryButton
+            size={buttonSize}
+            title="테스트 롤링페이퍼 생성"
+            onClick={handleCreateRecipientsClick}
+          />
+          <PrimaryButton
+            size={buttonSize}
+            title="테스트 메시지 생성"
+            onClick={handleCreateMessagesClick}
+            disabled={recipients.length === 0}
+          />
+          <PrimaryButton
+            size={buttonSize}
+            title="테스트 리액션 생성"
+            onClick={handleCreateReactionsClick}
+            disabled={recipients.length === 0}
+          />
+        </Row>
+        <Row>
+          <PrimaryButton
+            style={
+              recipients.length === 0
+                ? undefined
+                : { backgroundColor: Colors.error }
+            }
+            size={buttonSize}
+            title="롤링페이퍼 삭제"
+            onClick={handleDeleteRecipientsClick}
+            disabled={recipients.length === 0}
+          />
+          <PrimaryButton
+            style={
+              recipients.length === 0
+                ? undefined
+                : { backgroundColor: Colors.error }
+            }
+            size={buttonSize}
+            title="메시지 삭제"
+            onClick={handleDeleteMessagesClick}
+            disabled={recipients.length === 0}
+          />
+        </Row>
+        <h2>{`현재 생성된 롤링페이퍼 (${recipients.length}개)`}</h2>
+        {recipients.length > 0 && (
+          <RecipientsTable
+            recipients={recipients}
+            onClick={handleRecipientClick}
+          />
+        )}
+        {selectedRecipient && (
+          <h2>{`${selectedRecipient.name} 에게 달린 메시지 (${
+            messages.length ?? 0
+          }개)`}</h2>
+        )}
+        {messages.length > 0 && <MessagesTable messages={messages} />}
+        {selectedRecipient && (
+          <h2>{`${selectedRecipient.name} 에게 달린 리액션 (${
+            reactions.length ?? 0
+          }개)`}</h2>
+        )}
+        {reactions.length > 0 && <ReactionsTable reactions={reactions} />}
+      </Column>
+    </Page>
+  );
+}
+
+export default TestApiPage;

--- a/src/tests/test-api-page.jsx
+++ b/src/tests/test-api-page.jsx
@@ -189,6 +189,11 @@ function TestApiPage() {
     const recipientId = prompt("추가할 recipient id", "");
     await createMessages({ recipientId });
     updateRecipients();
+
+    if (selectedRecipient) {
+      const messages = await getAllMessages({ recipientId });
+      setMessages(messages);
+    }
   };
 
   const handleDeleteMessagesClick = async () => {
@@ -211,6 +216,11 @@ function TestApiPage() {
     const recipientId = prompt("추가할 recipient id", "");
     await createReactions({ recipientId });
     updateRecipients();
+
+    if (selectedRecipient) {
+      const reactions = await getAllReactions({ recipientId });
+      setReactions(reactions);
+    }
   };
 
   useEffect(() => {

--- a/src/tests/test-api.js
+++ b/src/tests/test-api.js
@@ -1,0 +1,77 @@
+import { apiClient } from "../api/client";
+import messageBody from "./test-message-body.json";
+import reactionBody from "./test-reaction-body.json";
+import recipientBody from "./test-recipient-body.json";
+
+/* Recipients */
+
+export async function createRecipients() {
+  let promises = [];
+  for (const body of recipientBody) {
+    const promise = apiClient.post("recipients/", body);
+    promises.push(promise);
+  }
+  await Promise.all(promises);
+}
+
+export async function getAllRecipients() {
+  const response = await apiClient.get("/recipients/?limit=20");
+  return response.data.results;
+}
+
+export async function deleteAllRecipients(recipients) {
+  let promises = [];
+  for (const recipient of recipients) {
+    const promise = apiClient.delete(`recipients/${recipient.id}/`);
+    promises.push(promise);
+  }
+  await Promise.all(promises);
+}
+
+/* Messages */
+
+export async function createMessages({ recipientId }) {
+  let promises = [];
+  for (const body of messageBody) {
+    const promise = apiClient.post(`recipients/${recipientId}/messages/`, body);
+    promises.push(promise);
+  }
+  await Promise.all(promises);
+}
+
+export async function getAllMessages({ recipientId }) {
+  const response = await apiClient.get(
+    `/recipients/${recipientId}/messages/?limit=20`
+  );
+  return response.data.results;
+}
+
+export async function deleteAllMessages(messages) {
+  let promises = [];
+  for (const message of messages) {
+    const promise = apiClient.delete(`messages/${message.id}/`);
+    promises.push(promise);
+  }
+  await Promise.all(promises);
+}
+
+/* Reactions */
+
+export async function createReactions({ recipientId }) {
+  let promises = [];
+  for (const body of reactionBody) {
+    const promise = apiClient.post(
+      `recipients/${recipientId}/reactions/`,
+      body
+    );
+    promises.push(promise);
+  }
+  await Promise.all(promises);
+}
+
+export async function getAllReactions({ recipientId }) {
+  const response = await apiClient.get(
+    `/recipients/${recipientId}/reactions/?limit=10`
+  );
+  return response.data.results;
+}

--- a/src/tests/test-api.js
+++ b/src/tests/test-api.js
@@ -60,11 +60,14 @@ export async function deleteAllMessages(messages) {
 export async function createReactions({ recipientId }) {
   let promises = [];
   for (const body of reactionBody) {
-    const promise = apiClient.post(
-      `recipients/${recipientId}/reactions/`,
-      body
-    );
-    promises.push(promise);
+    const randomCount = Math.ceil(Math.random() * 10);
+    Array.from({ length: randomCount }).forEach(() => {
+      const promise = apiClient.post(
+        `recipients/${recipientId}/reactions/`,
+        body
+      );
+      promises.push(promise);
+    });
   }
   await Promise.all(promises);
 }

--- a/src/tests/test-components-page.jsx
+++ b/src/tests/test-components-page.jsx
@@ -28,7 +28,7 @@ const OutlinedHeader = styled(Header)`
   border: 1px solid black;
 `;
 
-function TestPage() {
+function TestComponentsPage() {
   /* Dropdown type TextField */
   const [option1, setOption1] = useState();
   const [option2, setOption2] = useState();
@@ -251,4 +251,4 @@ function TestPage() {
   );
 }
 
-export default TestPage;
+export default TestComponentsPage;

--- a/src/tests/test-message-body.json
+++ b/src/tests/test-message-body.json
@@ -1,0 +1,142 @@
+[
+  {
+    "sender": "이혜진",
+    "profileImageURL": "https://picsum.photos/id/522/100/100",
+    "relationship": "친구",
+    "content": "축하해! 항상 밝은 모습이 너무 보기 좋아. 올해도 건강하고 행복한 일만 가득하길 바라~",
+    "font": "Pretendard"
+  },
+  {
+    "sender": "박성민",
+    "profileImageURL": "https://picsum.photos/id/547/100/100",
+    "relationship": "동료",
+    "content": "정말 축하드립니다! 함께 일하면서 많이 배우고 있어요. 앞으로도 잘 부탁드려요!",
+    "font": "Noto Sans"
+  },
+  {
+    "sender": "김소영",
+    "profileImageURL": "https://picsum.photos/id/268/100/100",
+    "relationship": "가족",
+    "content": "축하해♡ 엄마가 항상 응원하고 있다는 거 알지? 사랑해!",
+    "font": "나눔손글씨 손편지체"
+  },
+  {
+    "sender": "최준영",
+    "profileImageURL": "https://picsum.photos/id/1082/100/100",
+    "relationship": "친구",
+    "content": "축하한다! 오늘 저녁에 맛있는 거 먹으러 가자. 내가 쏠게!",
+    "font": "Pretendard"
+  },
+  {
+    "sender": "정은지",
+    "profileImageURL": "https://picsum.photos/id/571/100/100",
+    "relationship": "지인",
+    "content": "축하해요! 늘 웃는 모습이 인상적이에요. 좋은 하루 보내세요~",
+    "font": "나눔명조"
+  },
+  {
+    "sender": "장현석",
+    "profileImageURL": "https://picsum.photos/id/494/100/100",
+    "relationship": "친구",
+    "content": "축하해! 시간 진짜 빠르다. 오늘 하루 특별하게 보내!",
+    "font": "Pretendard"
+  },
+  {
+    "sender": "윤서현",
+    "profileImageURL": "https://picsum.photos/id/859/100/100",
+    "relationship": "동료",
+    "content": "축하드려요! 덕분에 프로젝트가 잘 진행되고 있어요. 감사합니다!",
+    "font": "Noto Sans"
+  },
+  {
+    "sender": "김태호",
+    "profileImageURL": "https://picsum.photos/id/437/100/100",
+    "relationship": "친구",
+    "content": "축하해! 정말 수고 많았어. 이제 새로운 시작이네!",
+    "font": "나눔명조"
+  },
+  {
+    "sender": "박미영",
+    "profileImageURL": "https://picsum.photos/id/1064/100/100",
+    "relationship": "친구",
+    "content": "드디어구나~ 그동안 정말 열심히 했어. 앞으로도 화이팅!",
+    "font": "나눔손글씨 손편지체"
+  },
+  {
+    "sender": "이준수",
+    "profileImageURL": "https://learn-codeit-kr-static.s3.ap-northeast-2.amazonaws.com/sprint-proj-image/default_avatar.png",
+    "relationship": "지인",
+    "content": "축하드려요! 앞으로의 새로운 도전을 응원합니다.",
+    "font": "나눔명조"
+  },
+  {
+    "sender": "최유나",
+    "profileImageURL": "https://picsum.photos/id/522/100/100",
+    "relationship": "친구",
+    "content": "축하해♡ 우리 추억 정말 많았는데 이제 또 새로운 추억 만들어가자!",
+    "font": "Pretendard"
+  },
+  {
+    "sender": "강민호",
+    "profileImageURL": "https://picsum.photos/id/547/100/100",
+    "relationship": "동료",
+    "content": "축하합니다! 함께 활동했던 시간이 좋은 추억이에요.",
+    "font": "Noto Sans"
+  },
+  {
+    "sender": "홍서윤",
+    "profileImageURL": "https://picsum.photos/id/268/100/100",
+    "relationship": "가족",
+    "content": "축하해! 언니가 너무 자랑스러워. 앞으로 하고 싶은 일 다 해봐!",
+    "font": "나눔손글씨 손편지체"
+  },
+  {
+    "sender": "노진우",
+    "profileImageURL": "https://picsum.photos/id/1082/100/100",
+    "relationship": "친구",
+    "content": "축하해! 새로운 변화가 기대되네. 응원할게!",
+    "font": "Pretendard"
+  },
+  {
+    "sender": "임소은",
+    "profileImageURL": "https://picsum.photos/id/571/100/100",
+    "relationship": "친구",
+    "content": "정말 축하해! 그동안 고생 많았어. 이제 좋은 일만 있을 거야!",
+    "font": "나눔명조"
+  },
+  {
+    "sender": "조민석",
+    "profileImageURL": "https://picsum.photos/id/494/100/100",
+    "relationship": "지인",
+    "content": "축하드려요! 앞으로의 여정을 응원합니다.",
+    "font": "Noto Sans"
+  },
+  {
+    "sender": "김다은",
+    "profileImageURL": "https://picsum.photos/id/859/100/100",
+    "relationship": "친구",
+    "content": "축하해! 정말 열심히 하더니 결실을 맺었네. 너무 축하해!",
+    "font": "Pretendard"
+  },
+  {
+    "sender": "이현우",
+    "profileImageURL": "https://picsum.photos/id/437/100/100",
+    "relationship": "동료",
+    "content": "축하드립니다! 앞으로도 많이 배우고 싶어요.",
+    "font": "Noto Sans"
+  },
+  {
+    "sender": "박지민",
+    "profileImageURL": "https://picsum.photos/id/1064/100/100",
+    "relationship": "가족",
+    "content": "축하해! 아빠가 정말 자랑스럽다. 건강 조심하고 화이팅!",
+    "font": "나눔명조"
+  },
+  {
+    "sender": "정수빈",
+    "profileImageURL": "https://learn-codeit-kr-static.s3.ap-northeast-2.amazonaws.com/sprint-proj-image/default_avatar.png",
+    "relationship": "친구",
+    "content": "축하축하~ 이제 더 바빠지겠네. 건강 챙기면서 해!",
+    "font": "Pretendard"
+  }
+]

--- a/src/tests/test-reaction-body.json
+++ b/src/tests/test-reaction-body.json
@@ -1,0 +1,42 @@
+[
+  {
+    "emoji": "👏",
+    "type": "increase"
+  },
+  {
+    "emoji": "🎉",
+    "type": "increase"
+  },
+  {
+    "emoji": "❤️",
+    "type": "increase"
+  },
+  {
+    "emoji": "👍",
+    "type": "increase"
+  },
+  {
+    "emoji": "🔥",
+    "type": "increase"
+  },
+  {
+    "emoji": "😊",
+    "type": "increase"
+  },
+  {
+    "emoji": "💪",
+    "type": "increase"
+  },
+  {
+    "emoji": "🎊",
+    "type": "increase"
+  },
+  {
+    "emoji": "✨",
+    "type": "increase"
+  },
+  {
+    "emoji": "🙌",
+    "type": "increase"
+  }
+]

--- a/src/tests/test-recipient-body.json
+++ b/src/tests/test-recipient-body.json
@@ -1,0 +1,90 @@
+[
+  {
+    "name": "김민수",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/id/683/3840/2160"
+  },
+  {
+    "name": "이지영",
+    "backgroundColor": "purple"
+  },
+  {
+    "name": "박준호",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/id/24/3840/2160"
+  },
+  {
+    "name": "최서연",
+    "backgroundColor": "green"
+  },
+  {
+    "name": "정태윤",
+    "backgroundColor": "beige"
+  },
+  {
+    "name": "한소희",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/id/599/3840/2160"
+  },
+  {
+    "name": "임재현",
+    "backgroundColor": "blue"
+  },
+  {
+    "name": "송유진",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/id/1058/3840/2160"
+  },
+  {
+    "name": "강동훈",
+    "backgroundColor": "beige"
+  },
+  {
+    "name": "윤미래",
+    "backgroundColor": "purple"
+  },
+  {
+    "name": "조현우",
+    "backgroundColor": "blue",
+    "backgroundImageURL": "https://picsum.photos/id/683/3840/2160"
+  },
+  {
+    "name": "배수지",
+    "backgroundColor": "green"
+  },
+  {
+    "name": "신예린",
+    "backgroundColor": "beige"
+  },
+  {
+    "name": "오준석",
+    "backgroundColor": "purple",
+    "backgroundImageURL": "https://picsum.photos/id/24/3840/2160"
+  },
+  {
+    "name": "안채원",
+    "backgroundColor": "blue"
+  },
+  {
+    "name": "문지훈",
+    "backgroundColor": "green"
+  },
+  {
+    "name": "서다은",
+    "backgroundColor": "beige",
+    "backgroundImageURL": "https://picsum.photos/id/599/3840/2160"
+  },
+  {
+    "name": "황민규",
+    "backgroundColor": "purple"
+  },
+  {
+    "name": "김나영",
+    "backgroundColor": "blue"
+  },
+  {
+    "name": "이도현",
+    "backgroundColor": "green",
+    "backgroundImageURL": "https://picsum.photos/id/1058/3840/2160"
+  }
+]


### PR DESCRIPTION
## 📝 작업 내용

- API 연동을 위한 사전 작업을 진행했습니다.
- 우리 팀(18-3) 개발 서버에 아직 데이터가 없어서, 먼저 테스트 데이터를 개발 서버에 추가하였습니다.
- 그 과정에서, 테스트 데이터의 추가/확인/삭제를 위한 테스트 페이지를 개발하였습니다(`test-api` path).
  - '테스트 롤링페이퍼 생성' 버튼을 클릭하면 20개의 미리 준비된 recipient data를 생성합니다.
  - '테스트 메시지 생성' 버튼을 클릭하고 recipient id를 입력하면 특정 recipient에 20개의 미리 준비된 message data를 생성합니다.
  - '테스트 리액션 생성' 버튼을 클릭하고 recipient id를 입력하면 특정 recipient에 20개의 미리 준비된 reaction data를 생성합니다.
  - '롤링페이퍼 삭제' 및 '메시지 삭제' 버튼을 클릭하면 전체 테스트 데이터를 삭제합니다. (아직 특정 데이터를 개별적으로 삭제하는 기능은 없습니다.)
- 기존 `test-page.jsx`는 `test-components`라는 path와 이름을 맞춰서 `test-components-page.jsx`로 이름을 변경하고, `src/tests` 경로로 이동하였습니다.

## 📷 스크린샷 (선택)

<img width="1481" height="797" alt="image" src="https://github.com/user-attachments/assets/266d19c6-73d8-4fa8-b5bf-bc6b2b665f8a" />

## 💬 리뷰어에게 남길 말 (선택)

- 테스트 데이터를 관리하는 다른 방법이 필요하다면 자유롭게 추가해 보시거나, 저에게 요청해주세요.