### PR TITLE
[#75] 카드 배경이미지, 프로필 이미지 등 로딩 애니메이션 추가, 카드 스크롤시 카드단위로 보이도록 기능 추가

### DIFF
--- a/src/features/rolling-paper/api/mock-rolling-paper-list.json
+++ b/src/features/rolling-paper/api/mock-rolling-paper-list.json
@@ -88,10 +88,10 @@
       {
         "id": 30238,
         "recipientId": 43558,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/340/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 32",
+        "content": "차은우님의 메세지 내용 32",
         "font": "Nanum Gothic",
         "createdAt": "2023-06-17T00:31:29Z"
       },
@@ -171,7 +171,7 @@
   },
   {
     "id": 18499,
-    "name": "이병헌",
+    "name": "차은우 차은우 차은우 차은우 차은우 차은우 차은우",
     "backgroundColor": "beige",
     "backgroundImageURL": "https://picsum.photos/seed/18499/600/400",
     "createdAt": "2023-06-03T04:15:47Z",
@@ -180,10 +180,10 @@
       {
         "id": 48979,
         "recipientId": 18499,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/11/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 77",
+        "content": "차은우님의 메세지 내용 77",
         "font": "Nanum Gothic",
         "createdAt": "2023-08-25T00:15:25Z"
       },
@@ -200,10 +200,10 @@
       {
         "id": 35753,
         "recipientId": 18499,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/173/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 67",
+        "content": "차은우님의 메세지 내용 67",
         "font": "Nanum Gothic",
         "createdAt": "2023-07-23T23:14:30Z"
       }
@@ -332,7 +332,7 @@
   },
   {
     "id": 13425,
-    "name": "이병헌",
+    "name": "차은우",
     "backgroundColor": "beige",
     "backgroundImageURL": "https://picsum.photos/seed/13425/600/400",
     "createdAt": "2023-07-06T20:30:52Z",
@@ -419,10 +419,10 @@
       {
         "id": 34424,
         "recipientId": 97436,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/141/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 6",
+        "content": "차은우님의 메세지 내용 6",
         "font": "Nanum Gothic",
         "createdAt": "2023-06-01T12:35:35Z"
       },
@@ -465,7 +465,7 @@
   },
   {
     "id": 22932,
-    "name": "이병헌",
+    "name": "차은우",
     "backgroundColor": "blue",
     "backgroundImageURL": "https://picsum.photos/seed/22932/600/400",
     "createdAt": "2023-12-21T05:29:02Z",
@@ -615,10 +615,10 @@
       {
         "id": 88963,
         "recipientId": 2194,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/317/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 81",
+        "content": "차은우님의 메세지 내용 81",
         "font": "Nanum Gothic",
         "createdAt": "2023-03-12T08:38:10Z"
       }
@@ -758,7 +758,7 @@
   },
   {
     "id": 45901,
-    "name": "이병헌",
+    "name": "차은우",
     "backgroundColor": "purple",
     "backgroundImageURL": null,
     "createdAt": "2023-06-14T15:34:31Z",
@@ -898,10 +898,10 @@
       {
         "id": 99518,
         "recipientId": 84532,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/2/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 83",
+        "content": "차은우님의 메세지 내용 83",
         "font": "Nanum Gothic",
         "createdAt": "2023-07-12T22:08:05Z"
       },
@@ -965,10 +965,10 @@
       {
         "id": 72173,
         "recipientId": 85839,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/137/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 84",
+        "content": "차은우님의 메세지 내용 84",
         "font": "Pretendard",
         "createdAt": "2023-04-01T12:40:19Z"
       }
@@ -1049,10 +1049,10 @@
       {
         "id": 20559,
         "recipientId": 76172,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/315/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 53",
+        "content": "차은우님의 메세지 내용 53",
         "font": "Roboto",
         "createdAt": "2023-07-06T05:06:42Z"
       },
@@ -1151,10 +1151,10 @@
       {
         "id": 26243,
         "recipientId": 525,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/470/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 36",
+        "content": "차은우님의 메세지 내용 36",
         "font": "Noto Sans",
         "createdAt": "2024-02-01T22:09:11Z"
       },
@@ -1313,10 +1313,10 @@
       {
         "id": 8442,
         "recipientId": 76854,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/391/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 6",
+        "content": "차은우님의 메세지 내용 6",
         "font": "Pretendard",
         "createdAt": "2023-12-21T09:27:19Z"
       },
@@ -1360,10 +1360,10 @@
       {
         "id": 3111,
         "recipientId": 50919,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/384/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 80",
+        "content": "차은우님의 메세지 내용 80",
         "font": "Pretendard",
         "createdAt": "2023-08-12T11:51:00Z"
       },
@@ -1586,7 +1586,7 @@
   },
   {
     "id": 5465,
-    "name": "이병헌",
+    "name": "차은우",
     "backgroundColor": "beige",
     "backgroundImageURL": null,
     "createdAt": "2023-01-10T18:10:25Z",
@@ -1893,10 +1893,10 @@
       {
         "id": 66552,
         "recipientId": 90385,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/498/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 36",
+        "content": "차은우님의 메세지 내용 36",
         "font": "Noto Sans",
         "createdAt": "2023-10-17T11:54:41Z"
       }
@@ -2004,10 +2004,10 @@
       {
         "id": 59673,
         "recipientId": 39122,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/467/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 15",
+        "content": "차은우님의 메세지 내용 15",
         "font": "Nanum Gothic",
         "createdAt": "2023-03-20T07:58:11Z"
       },
@@ -2075,10 +2075,10 @@
       {
         "id": 87956,
         "recipientId": 36279,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/362/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 45",
+        "content": "차은우님의 메세지 내용 45",
         "font": "Pretendard",
         "createdAt": "2023-01-10T01:43:19Z"
       }
@@ -2269,10 +2269,10 @@
       {
         "id": 60985,
         "recipientId": 2640,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/440/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 52",
+        "content": "차은우님의 메세지 내용 52",
         "font": "Pretendard",
         "createdAt": "2023-05-11T23:03:58Z"
       },
@@ -2643,20 +2643,20 @@
       {
         "id": 96788,
         "recipientId": 73648,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/249/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 54",
+        "content": "차은우님의 메세지 내용 54",
         "font": "Nanum Gothic",
         "createdAt": "2023-09-16T01:58:06Z"
       },
       {
         "id": 20726,
         "recipientId": 73648,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/431/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 78",
+        "content": "차은우님의 메세지 내용 78",
         "font": "Pretendard",
         "createdAt": "2023-07-25T07:59:44Z"
       }
@@ -2991,10 +2991,10 @@
       {
         "id": 65998,
         "recipientId": 73391,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/117/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 7",
+        "content": "차은우님의 메세지 내용 7",
         "font": "Noto Sans",
         "createdAt": "2023-06-29T21:54:39Z"
       }
@@ -3166,7 +3166,7 @@
   },
   {
     "id": 26744,
-    "name": "이병헌",
+    "name": "차은우",
     "backgroundColor": "beige",
     "backgroundImageURL": null,
     "createdAt": "2023-03-23T03:14:00Z",
@@ -3277,10 +3277,10 @@
       {
         "id": 35228,
         "recipientId": 90477,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/94/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 63",
+        "content": "차은우님의 메세지 내용 63",
         "font": "Roboto",
         "createdAt": "2023-05-25T06:02:55Z"
       },
@@ -3574,7 +3574,7 @@
   },
   {
     "id": 31714,
-    "name": "이병헌",
+    "name": "차은우",
     "backgroundColor": "beige",
     "backgroundImageURL": "https://picsum.photos/seed/31714/600/400",
     "createdAt": "2023-01-13T08:26:56Z",
@@ -3630,10 +3630,10 @@
       {
         "id": 88820,
         "recipientId": 24976,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/355/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 72",
+        "content": "차은우님의 메세지 내용 72",
         "font": "Pretendard",
         "createdAt": "2023-12-02T16:28:28Z"
       }
@@ -3759,10 +3759,10 @@
       {
         "id": 35658,
         "recipientId": 9191,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/62/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 27",
+        "content": "차은우님의 메세지 내용 27",
         "font": "Nanum Gothic",
         "createdAt": "2023-04-09T12:56:46Z"
       },
@@ -3779,10 +3779,10 @@
       {
         "id": 20041,
         "recipientId": 9191,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/114/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 72",
+        "content": "차은우님의 메세지 내용 72",
         "font": "Pretendard",
         "createdAt": "2023-11-11T12:43:30Z"
       }
@@ -3861,10 +3861,10 @@
       {
         "id": 53736,
         "recipientId": 625,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/411/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 98",
+        "content": "차은우님의 메세지 내용 98",
         "font": "Nanum Gothic",
         "createdAt": "2023-06-06T17:47:12Z"
       },
@@ -3922,10 +3922,10 @@
       {
         "id": 53607,
         "recipientId": 23417,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/402/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 96",
+        "content": "차은우님의 메세지 내용 96",
         "font": "Noto Sans",
         "createdAt": "2023-06-28T04:25:20Z"
       }
@@ -4063,10 +4063,10 @@
       {
         "id": 76625,
         "recipientId": 48647,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/256/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 98",
+        "content": "차은우님의 메세지 내용 98",
         "font": "Pretendard",
         "createdAt": "2023-03-21T02:42:08Z"
       },
@@ -4118,10 +4118,10 @@
       {
         "id": 90888,
         "recipientId": 7110,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/19/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 42",
+        "content": "차은우님의 메세지 내용 42",
         "font": "Roboto",
         "createdAt": "2023-09-16T18:15:50Z"
       },
@@ -4219,7 +4219,7 @@
   },
   {
     "id": 75973,
-    "name": "이병헌",
+    "name": "차은우",
     "backgroundColor": "beige",
     "backgroundImageURL": "https://picsum.photos/seed/75973/600/400",
     "createdAt": "2023-04-29T23:14:33Z",
@@ -4228,10 +4228,10 @@
       {
         "id": 85401,
         "recipientId": 75973,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/269/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 90",
+        "content": "차은우님의 메세지 내용 90",
         "font": "Noto Sans",
         "createdAt": "2023-11-12T05:17:44Z"
       },
@@ -4631,7 +4631,7 @@
   },
   {
     "id": 32314,
-    "name": "이병헌",
+    "name": "차은우",
     "backgroundColor": "purple",
     "backgroundImageURL": null,
     "createdAt": "2023-06-09T07:16:23Z",
@@ -4650,10 +4650,10 @@
       {
         "id": 10034,
         "recipientId": 32314,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/288/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 22",
+        "content": "차은우님의 메세지 내용 22",
         "font": "Pretendard",
         "createdAt": "2023-09-14T13:27:24Z"
       },
@@ -4801,10 +4801,10 @@
       {
         "id": 50489,
         "recipientId": 63219,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/11/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 77",
+        "content": "차은우님의 메세지 내용 77",
         "font": "Noto Sans",
         "createdAt": "2023-11-27T08:16:32Z"
       }
@@ -4819,7 +4819,7 @@
   },
   {
     "id": 32218,
-    "name": "이병헌",
+    "name": "차은우",
     "backgroundColor": "beige",
     "backgroundImageURL": null,
     "createdAt": "2023-07-22T22:33:51Z",
@@ -4946,10 +4946,10 @@
       {
         "id": 24988,
         "recipientId": 1341,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/423/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 64",
+        "content": "차은우님의 메세지 내용 64",
         "font": "Roboto",
         "createdAt": "2023-01-06T05:53:05Z"
       }
@@ -5011,7 +5011,7 @@
   },
   {
     "id": 93438,
-    "name": "이병헌",
+    "name": "차은우",
     "backgroundColor": "blue",
     "backgroundImageURL": "https://picsum.photos/seed/93438/600/400",
     "createdAt": "2023-04-02T11:00:53Z",
@@ -5030,10 +5030,10 @@
       {
         "id": 6156,
         "recipientId": 93438,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/109/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 59",
+        "content": "차은우님의 메세지 내용 59",
         "font": "Noto Sans",
         "createdAt": "2023-01-24T10:30:39Z"
       },
@@ -5058,7 +5058,7 @@
   },
   {
     "id": 44334,
-    "name": "이병헌",
+    "name": "차은우",
     "backgroundColor": "blue",
     "backgroundImageURL": "https://picsum.photos/seed/44334/600/400",
     "createdAt": "2023-12-30T01:42:47Z",
@@ -5152,7 +5152,7 @@
   },
   {
     "id": 44928,
-    "name": "이병헌",
+    "name": "차은우",
     "backgroundColor": "beige",
     "backgroundImageURL": null,
     "createdAt": "2023-11-24T12:12:26Z",
@@ -5192,10 +5192,10 @@
       {
         "id": 31761,
         "recipientId": 94539,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/62/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 53",
+        "content": "차은우님의 메세지 내용 53",
         "font": "Pretendard",
         "createdAt": "2023-04-17T18:23:36Z"
       },
@@ -5666,10 +5666,10 @@
       {
         "id": 41596,
         "recipientId": 43809,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/439/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 36",
+        "content": "차은우님의 메세지 내용 36",
         "font": "Roboto",
         "createdAt": "2023-02-12T07:13:07Z"
       },
@@ -5778,10 +5778,10 @@
       {
         "id": 62162,
         "recipientId": 62125,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/293/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 93",
+        "content": "차은우님의 메세지 내용 93",
         "font": "Roboto",
         "createdAt": "2023-04-29T23:05:56Z"
       }
@@ -5872,10 +5872,10 @@
       {
         "id": 91516,
         "recipientId": 58844,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/108/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 82",
+        "content": "차은우님의 메세지 내용 82",
         "font": "Pretendard",
         "createdAt": "2023-08-27T12:05:46Z"
       }
@@ -5909,10 +5909,10 @@
       {
         "id": 29903,
         "recipientId": 72437,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/106/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 40",
+        "content": "차은우님의 메세지 내용 40",
         "font": "Roboto",
         "createdAt": "2023-04-29T16:49:48Z"
       }
@@ -5956,10 +5956,10 @@
       {
         "id": 91691,
         "recipientId": 31124,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/461/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 53",
+        "content": "차은우님의 메세지 내용 53",
         "font": "Roboto",
         "createdAt": "2023-05-21T09:55:42Z"
       }
@@ -5978,7 +5978,7 @@
   },
   {
     "id": 73111,
-    "name": "이병헌",
+    "name": "차은우",
     "backgroundColor": "blue",
     "backgroundImageURL": null,
     "createdAt": "2023-12-29T11:24:51Z",
@@ -6034,10 +6034,10 @@
       {
         "id": 2974,
         "recipientId": 44599,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/46/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 13",
+        "content": "차은우님의 메세지 내용 13",
         "font": "Roboto",
         "createdAt": "2023-11-11T07:56:34Z"
       },
@@ -6256,7 +6256,7 @@
   },
   {
     "id": 72332,
-    "name": "이병헌",
+    "name": "차은우",
     "backgroundColor": "purple",
     "backgroundImageURL": "https://picsum.photos/seed/72332/600/400",
     "createdAt": "2023-10-08T20:12:12Z",
@@ -6359,10 +6359,10 @@
       {
         "id": 47612,
         "recipientId": 6048,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/97/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 72",
+        "content": "차은우님의 메세지 내용 72",
         "font": "Pretendard",
         "createdAt": "2023-12-11T12:42:57Z"
       },
@@ -6416,10 +6416,10 @@
       {
         "id": 54283,
         "recipientId": 7768,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/368/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 8",
+        "content": "차은우님의 메세지 내용 8",
         "font": "Nanum Gothic",
         "createdAt": "2023-02-19T15:25:55Z"
       },
@@ -6473,10 +6473,10 @@
       {
         "id": 66344,
         "recipientId": 60032,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/444/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 47",
+        "content": "차은우님의 메세지 내용 47",
         "font": "Pretendard",
         "createdAt": "2023-07-26T07:54:55Z"
       }
@@ -6806,10 +6806,10 @@
       {
         "id": 48175,
         "recipientId": 96506,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/145/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 86",
+        "content": "차은우님의 메세지 내용 86",
         "font": "Pretendard",
         "createdAt": "2023-03-13T10:17:35Z"
       },
@@ -6971,10 +6971,10 @@
       {
         "id": 11805,
         "recipientId": 10732,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/76/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 48",
+        "content": "차은우님의 메세지 내용 48",
         "font": "Nanum Gothic",
         "createdAt": "2023-12-29T05:06:21Z"
       }
@@ -7063,10 +7063,10 @@
       {
         "id": 94450,
         "recipientId": 64061,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/353/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 61",
+        "content": "차은우님의 메세지 내용 61",
         "font": "Pretendard",
         "createdAt": "2023-12-02T06:48:01Z"
       },
@@ -7091,7 +7091,7 @@
   },
   {
     "id": 15549,
-    "name": "이병헌",
+    "name": "차은우",
     "backgroundColor": "blue",
     "backgroundImageURL": null,
     "createdAt": "2023-12-13T10:07:11Z",
@@ -7161,10 +7161,10 @@
       {
         "id": 67124,
         "recipientId": 84213,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/482/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 81",
+        "content": "차은우님의 메세지 내용 81",
         "font": "Pretendard",
         "createdAt": "2023-04-16T14:42:59Z"
       },
@@ -7245,10 +7245,10 @@
       {
         "id": 91701,
         "recipientId": 83558,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/169/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 97",
+        "content": "차은우님의 메세지 내용 97",
         "font": "Noto Sans",
         "createdAt": "2023-11-22T09:50:03Z"
       },
@@ -7347,10 +7347,10 @@
       {
         "id": 86215,
         "recipientId": 1220,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/419/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 25",
+        "content": "차은우님의 메세지 내용 25",
         "font": "Pretendard",
         "createdAt": "2023-05-10T21:59:12Z"
       }
@@ -7369,7 +7369,7 @@
   },
   {
     "id": 53959,
-    "name": "이병헌",
+    "name": "차은우",
     "backgroundColor": "blue",
     "backgroundImageURL": "https://picsum.photos/seed/53959/600/400",
     "createdAt": "2023-08-24T05:22:48Z",
@@ -7398,10 +7398,10 @@
       {
         "id": 59151,
         "recipientId": 53959,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/10/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 4",
+        "content": "차은우님의 메세지 내용 4",
         "font": "Nanum Gothic",
         "createdAt": "2023-03-11T07:04:18Z"
       }
@@ -7471,7 +7471,7 @@
   },
   {
     "id": 51432,
-    "name": "이병헌",
+    "name": "차은우",
     "backgroundColor": "beige",
     "backgroundImageURL": "https://picsum.photos/seed/51432/600/400",
     "createdAt": "2023-11-07T07:07:37Z",
@@ -7490,10 +7490,10 @@
       {
         "id": 33808,
         "recipientId": 51432,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/478/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 8",
+        "content": "차은우님의 메세지 내용 8",
         "font": "Pretendard",
         "createdAt": "2023-04-04T10:06:15Z"
       },
@@ -7891,10 +7891,10 @@
       {
         "id": 93059,
         "recipientId": 73798,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/252/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 99",
+        "content": "차은우님의 메세지 내용 99",
         "font": "Roboto",
         "createdAt": "2023-11-21T09:01:45Z"
       },
@@ -7993,10 +7993,10 @@
       {
         "id": 33941,
         "recipientId": 3992,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/364/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 93",
+        "content": "차은우님의 메세지 내용 93",
         "font": "Pretendard",
         "createdAt": "2023-02-13T23:03:26Z"
       },
@@ -8087,10 +8087,10 @@
       {
         "id": 89359,
         "recipientId": 63758,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/401/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 53",
+        "content": "차은우님의 메세지 내용 53",
         "font": "Roboto",
         "createdAt": "2023-05-10T19:04:15Z"
       },
@@ -8193,7 +8193,7 @@
   },
   {
     "id": 63096,
-    "name": "이병헌",
+    "name": "차은우",
     "backgroundColor": "blue",
     "backgroundImageURL": "https://picsum.photos/seed/63096/600/400",
     "createdAt": "2023-08-25T09:30:08Z",
@@ -8202,10 +8202,10 @@
       {
         "id": 72995,
         "recipientId": 63096,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/368/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 44",
+        "content": "차은우님의 메세지 내용 44",
         "font": "Pretendard",
         "createdAt": "2023-10-07T18:41:59Z"
       },
@@ -8253,10 +8253,10 @@
       {
         "id": 44494,
         "recipientId": 13289,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/118/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 64",
+        "content": "차은우님의 메세지 내용 64",
         "font": "Nanum Gothic",
         "createdAt": "2024-01-29T16:37:33Z"
       },
@@ -8541,10 +8541,10 @@
       {
         "id": 33150,
         "recipientId": 66190,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/26/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 47",
+        "content": "차은우님의 메세지 내용 47",
         "font": "Roboto",
         "createdAt": "2024-01-22T00:03:15Z"
       }
@@ -8563,7 +8563,7 @@
   },
   {
     "id": 68635,
-    "name": "이병헌",
+    "name": "차은우",
     "backgroundColor": "beige",
     "backgroundImageURL": null,
     "createdAt": "2023-10-22T10:14:45Z",
@@ -8619,10 +8619,10 @@
       {
         "id": 8378,
         "recipientId": 52236,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/383/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 53",
+        "content": "차은우님의 메세지 내용 53",
         "font": "Pretendard",
         "createdAt": "2023-12-03T19:03:51Z"
       }
@@ -8656,10 +8656,10 @@
       {
         "id": 14027,
         "recipientId": 81115,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/400/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 48",
+        "content": "차은우님의 메세지 내용 48",
         "font": "Noto Sans",
         "createdAt": "2023-09-18T14:09:01Z"
       },
@@ -8862,10 +8862,10 @@
       {
         "id": 16314,
         "recipientId": 60,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/345/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 52",
+        "content": "차은우님의 메세지 내용 52",
         "font": "Roboto",
         "createdAt": "2023-03-07T04:55:33Z"
       }
@@ -8903,10 +8903,10 @@
       {
         "id": 81467,
         "recipientId": 66554,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/487/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 17",
+        "content": "차은우님의 메세지 내용 17",
         "font": "Nanum Gothic",
         "createdAt": "2023-03-16T05:19:39Z"
       },
@@ -9083,10 +9083,10 @@
       {
         "id": 19962,
         "recipientId": 31459,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/80/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 11",
+        "content": "차은우님의 메세지 내용 11",
         "font": "Nanum Gothic",
         "createdAt": "2023-11-26T04:31:20Z"
       }
@@ -9269,10 +9269,10 @@
       {
         "id": 24156,
         "recipientId": 41885,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/360/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 14",
+        "content": "차은우님의 메세지 내용 14",
         "font": "Noto Sans",
         "createdAt": "2023-07-13T21:35:18Z"
       },
@@ -9599,20 +9599,20 @@
       {
         "id": 86564,
         "recipientId": 46642,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/36/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 78",
+        "content": "차은우님의 메세지 내용 78",
         "font": "Noto Sans",
         "createdAt": "2023-09-23T23:48:17Z"
       },
       {
         "id": 46880,
         "recipientId": 46642,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/453/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 92",
+        "content": "차은우님의 메세지 내용 92",
         "font": "Noto Sans",
         "createdAt": "2023-06-07T09:44:08Z"
       },
@@ -9688,7 +9688,7 @@
   },
   {
     "id": 93469,
-    "name": "이병헌",
+    "name": "차은우",
     "backgroundColor": "beige",
     "backgroundImageURL": "https://picsum.photos/seed/93469/600/400",
     "createdAt": "2023-08-05T08:37:01Z",
@@ -9743,7 +9743,7 @@
   },
   {
     "id": 45950,
-    "name": "이병헌",
+    "name": "차은우",
     "backgroundColor": "green",
     "backgroundImageURL": "https://picsum.photos/seed/45950/600/400",
     "createdAt": "2023-04-24T21:39:46Z",
@@ -10156,10 +10156,10 @@
       {
         "id": 46241,
         "recipientId": 30047,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/397/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 64",
+        "content": "차은우님의 메세지 내용 64",
         "font": "Roboto",
         "createdAt": "2023-04-12T04:50:45Z"
       },
@@ -10433,7 +10433,7 @@
   },
   {
     "id": 44091,
-    "name": "이병헌",
+    "name": "차은우",
     "backgroundColor": "blue",
     "backgroundImageURL": "https://picsum.photos/seed/44091/600/400",
     "createdAt": "2023-06-17T19:51:45Z",
@@ -10871,10 +10871,10 @@
       {
         "id": 58525,
         "recipientId": 62965,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/103/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 1",
+        "content": "차은우님의 메세지 내용 1",
         "font": "Noto Sans",
         "createdAt": "2023-04-24T14:22:46Z"
       },
@@ -10908,10 +10908,10 @@
       {
         "id": 86114,
         "recipientId": 61614,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/1/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 48",
+        "content": "차은우님의 메세지 내용 48",
         "font": "Noto Sans",
         "createdAt": "2023-11-16T04:24:55Z"
       },
@@ -10997,7 +10997,7 @@
   },
   {
     "id": 31146,
-    "name": "이병헌",
+    "name": "차은우",
     "backgroundColor": "green",
     "backgroundImageURL": null,
     "createdAt": "2023-09-27T13:42:38Z",
@@ -11033,10 +11033,10 @@
       {
         "id": 80875,
         "recipientId": 99123,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/42/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 14",
+        "content": "차은우님의 메세지 내용 14",
         "font": "Roboto",
         "createdAt": "2023-11-30T19:44:40Z"
       },
@@ -11159,10 +11159,10 @@
       {
         "id": 9237,
         "recipientId": 16143,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/437/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 14",
+        "content": "차은우님의 메세지 내용 14",
         "font": "Pretendard",
         "createdAt": "2023-03-17T21:44:08Z"
       }
@@ -11253,10 +11253,10 @@
       {
         "id": 31892,
         "recipientId": 98422,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/8/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 43",
+        "content": "차은우님의 메세지 내용 43",
         "font": "Pretendard",
         "createdAt": "2023-09-02T03:23:20Z"
       }
@@ -11294,10 +11294,10 @@
       {
         "id": 85445,
         "recipientId": 53532,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/363/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 51",
+        "content": "차은우님의 메세지 내용 51",
         "font": "Noto Sans",
         "createdAt": "2023-09-23T11:29:56Z"
       },
@@ -11331,10 +11331,10 @@
       {
         "id": 86518,
         "recipientId": 93792,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/204/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 9",
+        "content": "차은우님의 메세지 내용 9",
         "font": "Roboto",
         "createdAt": "2023-01-22T13:44:09Z"
       },
@@ -11351,10 +11351,10 @@
       {
         "id": 9752,
         "recipientId": 93792,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/171/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 68",
+        "content": "차은우님의 메세지 내용 68",
         "font": "Roboto",
         "createdAt": "2023-02-15T23:39:35Z"
       }
@@ -11406,10 +11406,10 @@
       {
         "id": 84648,
         "recipientId": 12242,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/112/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 4",
+        "content": "차은우님의 메세지 내용 4",
         "font": "Pretendard",
         "createdAt": "2024-01-06T11:37:10Z"
       }
@@ -11492,10 +11492,10 @@
       {
         "id": 35816,
         "recipientId": 76148,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/488/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 96",
+        "content": "차은우님의 메세지 내용 96",
         "font": "Nanum Gothic",
         "createdAt": "2023-04-09T14:21:56Z"
       }
@@ -11556,10 +11556,10 @@
       {
         "id": 76780,
         "recipientId": 38642,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/253/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 24",
+        "content": "차은우님의 메세지 내용 24",
         "font": "Nanum Gothic",
         "createdAt": "2023-07-12T11:54:03Z"
       },
@@ -11728,10 +11728,10 @@
       {
         "id": 78207,
         "recipientId": 55884,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/155/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 87",
+        "content": "차은우님의 메세지 내용 87",
         "font": "Pretendard",
         "createdAt": "2023-06-01T07:21:37Z"
       },
@@ -11783,10 +11783,10 @@
       {
         "id": 2300,
         "recipientId": 65809,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/358/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 60",
+        "content": "차은우님의 메세지 내용 60",
         "font": "Roboto",
         "createdAt": "2023-05-12T09:25:19Z"
       },
@@ -11830,10 +11830,10 @@
       {
         "id": 12155,
         "recipientId": 47549,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/247/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 80",
+        "content": "차은우님의 메세지 내용 80",
         "font": "Pretendard",
         "createdAt": "2023-03-09T22:19:14Z"
       },
@@ -11897,10 +11897,10 @@
       {
         "id": 64811,
         "recipientId": 7135,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/184/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 9",
+        "content": "차은우님의 메세지 내용 9",
         "font": "Roboto",
         "createdAt": "2023-10-17T00:36:13Z"
       }
@@ -12332,10 +12332,10 @@
       {
         "id": 65322,
         "recipientId": 21977,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/156/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 79",
+        "content": "차은우님의 메세지 내용 79",
         "font": "Nanum Gothic",
         "createdAt": "2023-09-13T04:30:55Z"
       }
@@ -12367,10 +12367,10 @@
       {
         "id": 37649,
         "recipientId": 67245,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/160/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 84",
+        "content": "차은우님의 메세지 내용 84",
         "font": "Roboto",
         "createdAt": "2023-05-09T12:36:18Z"
       },
@@ -12741,10 +12741,10 @@
       {
         "id": 7778,
         "recipientId": 37498,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/202/200/200",
         "relationship": "가족",
-        "content": "이병헌님의 메세지 내용 24",
+        "content": "차은우님의 메세지 내용 24",
         "font": "Pretendard",
         "createdAt": "2023-12-27T07:03:22Z"
       },
@@ -12910,7 +12910,7 @@
   },
   {
     "id": 12700,
-    "name": "이병헌",
+    "name": "차은우",
     "backgroundColor": "purple",
     "backgroundImageURL": null,
     "createdAt": "2023-08-18T22:43:12Z",
@@ -12939,10 +12939,10 @@
       {
         "id": 4746,
         "recipientId": 12700,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/260/200/200",
         "relationship": "친구",
-        "content": "이병헌님의 메세지 내용 44",
+        "content": "차은우님의 메세지 내용 44",
         "font": "Noto Sans",
         "createdAt": "2023-02-17T03:59:23Z"
       }
@@ -13160,10 +13160,10 @@
       {
         "id": 47661,
         "recipientId": 56031,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/395/200/200",
         "relationship": "동료",
-        "content": "이병헌님의 메세지 내용 62",
+        "content": "차은우님의 메세지 내용 62",
         "font": "Nanum Gothic",
         "createdAt": "2023-08-20T17:27:35Z"
       },
@@ -13925,7 +13925,7 @@
   },
   {
     "id": 31249,
-    "name": "이병헌",
+    "name": "차은우",
     "backgroundColor": "blue",
     "backgroundImageURL": null,
     "createdAt": "2023-05-16T17:41:45Z",
@@ -13944,10 +13944,10 @@
       {
         "id": 54855,
         "recipientId": 31249,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/188/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 84",
+        "content": "차은우님의 메세지 내용 84",
         "font": "Pretendard",
         "createdAt": "2023-07-01T14:34:04Z"
       }
@@ -13966,7 +13966,7 @@
   },
   {
     "id": 87008,
-    "name": "이병헌",
+    "name": "차은우",
     "backgroundColor": "purple",
     "backgroundImageURL": null,
     "createdAt": "2023-05-31T18:24:49Z",
@@ -13985,10 +13985,10 @@
       {
         "id": 29069,
         "recipientId": 87008,
-        "sender": "이병헌",
+        "sender": "차은우",
         "profileImageURL": "https://picsum.photos/id/25/200/200",
         "relationship": "지인",
-        "content": "이병헌님의 메세지 내용 19",
+        "content": "차은우님의 메세지 내용 19",
         "font": "Roboto",
         "createdAt": "2024-01-14T03:59:30Z"
       },

--- a/src/features/rolling-paper/components/rolling-paper-list.jsx
+++ b/src/features/rolling-paper/components/rolling-paper-list.jsx
@@ -1,7 +1,10 @@
 import ArrowButton from "../../../components/button/arrow-button";
 import ARROW_BUTTON_DIRECTION from "../../../components/button/arrow-button-direction";
 import { media } from "../../../utils/media";
-import styled, { css } from "styled-components";
+import React, { useEffect, useState } from "react";
+import styled, { keyframes, css } from "styled-components";
+import Avatar from "../../../components/avatar/avatar";
+import AVATAR_SIZE from "../../../components/avatar/avatar-size";
 
 const backgroundColors = {
   beige: "#FFE2AD",
@@ -16,14 +19,15 @@ const CardContainer = styled.div`
   gap: 20px;
   width: fit-content;
   font-family: Pretendard;
-
   position: relative;
+  padding: 0;
 
   ${media.tablet} {
     display: flex;
     gap: 16px;
     overflow-x: auto;
     scroll-snap-type: x mandatory;
+    scroll-padding: 24px;
 
     scrollbar-width: none;
     -ms-overflow-style: none;
@@ -42,6 +46,10 @@ const CardContainer = styled.div`
     max-width: 767px;
     width: 100%;
     padding: 0 20px;
+
+    & > div {
+      flex: 0 0 208px;
+    }
   }
 `;
 
@@ -53,21 +61,22 @@ const CardItem = styled.div`
   padding: 30px 24px 20px 24px;
   border: 1px solid rgba(0, 0, 0, 0.1);
   box-shadow: 0px 2px 12px 0px rgba(0, 0, 0, 0.08);
-
+  z-index: 0;
   display: flex;
   gap: 12px;
   flex-direction: column;
-
-  background: ${(props) =>
-    props.$backgroundImageURL
-      ? `linear-gradient(rgba(0,0,0,0.4), rgba(0,0,0,0.4)), url(${props.$backgroundImageURL}) center/cover no-repeat`
-      : backgroundColors[props.$backgroundColor] || "white"};
-
   position: relative;
   overflow: hidden;
+  background: ${(props) => {
+    if (props.$backgroundImageURL) {
+      return `linear-gradient(rgba(0,0,0,0.4), rgba(0,0,0,0.4)), url(${props.$backgroundImageURL}) center/cover no-repeat`;
+    }
+    return backgroundColors[props.$backgroundColor] || "white";
+  }};
 
   ${media.tablet} {
     flex-shrink: 0;
+    scroll-snap-align: start;
   }
 
   ${media.mobile} {
@@ -76,11 +85,9 @@ const CardItem = styled.div`
     padding: 30px 15px 20px 15px;
   }
 
-  /* 배경 도형 */
   &::before {
     content: "";
     position: absolute;
-    z-index: 0;
     ${({ $backgroundImageURL, $backgroundColor }) => {
       return $backgroundImageURL ? "" : polygonStyle[$backgroundColor];
     }}
@@ -88,7 +95,6 @@ const CardItem = styled.div`
 
   & > * {
     position: relative;
-    z-index: 1;
   }
 `;
 
@@ -154,22 +160,26 @@ const CardTitle = styled.h2`
   font-size: 24px;
   font-weight: 700;
   color: ${(props) => props.$fontColor || "black"};
+  width: 225px;
+
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  ${media.mobile} {
+    width: 175px;
+    font-size: 18px;
+  }
 `;
 
 const ProfileContainer = styled.div`
   display: flex;
 `;
 
-const CardProfile = styled.img`
-  height: 28px;
-  width: 28px;
-  border-radius: 50%;
-  border: 1px solid #ffffff;
-
-  margin-left: -12px;
-  &:first-child {
-    margin-left: 0;
-  }
+const CardProfile = styled.div`
+  margin-left: ${($messageIndex) => ($messageIndex === 0 ? "0" : "-12px")};
 `;
 
 const OverProfile = styled.div`
@@ -268,7 +278,119 @@ const PreviewButtonWrapper = styled.div`
   z-index: 10;
 `;
 
+const spin = keyframes`
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+`;
+
+const Spinner = styled.div`
+  width: ${(props) => props.size || "40px"};
+  height: ${(props) => props.size || "40px"};
+  border: ${(props) => props.thickness || "4px"} solid
+    ${(props) => props.trackColor || "#f3f3f313"};
+  border-top: ${(props) => props.thickness || "4px"} solid
+    var(--color-purple-700);
+  border-radius: 50%;
+  animation: ${spin} 1s linear infinite;
+
+  ${(props) =>
+    props.centered &&
+    css`
+      margin: 0 auto;
+      display: block;
+    `}
+
+  position: absolute;
+  justify-self: anchor-center;
+  align-self: anchor-center;
+`;
+
 function RollingPaperList({ cardData, totalPages, currentPage, onTurnCards }) {
+  const [imageLoadStates, setImageLoadStates] = useState({});
+  const [profileLoadStates, setProfileLoadStates] = useState({});
+
+  useEffect(() => {
+    const loadImages = async () => {
+      const loadStates = {};
+
+      cardData.forEach((card) => {
+        if (card.backgroundImageURL) {
+          loadStates[card.id] = false;
+        }
+      });
+
+      setImageLoadStates(loadStates);
+
+      const imagePromises = cardData.map((card) => {
+        if (!card.backgroundImageURL) return Promise.resolve();
+
+        return new Promise((resolve) => {
+          const img = new Image();
+          img.onload = () => {
+            setImageLoadStates((prev) => ({
+              ...prev,
+              [card.id]: true,
+            }));
+            resolve();
+          };
+          img.onerror = () => {
+            setImageLoadStates((prev) => ({
+              ...prev,
+              [card.id]: false,
+            }));
+            resolve();
+          };
+          img.src = card.backgroundImageURL;
+        });
+      });
+
+      await Promise.all(imagePromises);
+    };
+
+    loadImages();
+  }, [cardData]);
+
+  useEffect(() => {
+    const loadProfileImages = async () => {
+      const initialStates = {};
+      cardData.forEach((card) => {
+        card.recentMessages.slice(0, 3).forEach((msg) => {
+          initialStates[msg.id] = false;
+        });
+      });
+      setProfileLoadStates(initialStates);
+
+      const promises = [];
+      cardData.forEach((card) => {
+        card.recentMessages.slice(0, 3).forEach((msg) => {
+          if (!msg.profileImageURL) return;
+          promises.push(
+            new Promise((resolve) => {
+              const img = new Image();
+              img.src = msg.profileImageURL;
+              img.onload = () => {
+                setProfileLoadStates((prev) => ({ ...prev, [msg.id]: true }));
+                resolve();
+              };
+              img.onerror = () => {
+                setProfileLoadStates((prev) => ({ ...prev, [msg.id]: false }));
+                resolve();
+              };
+            })
+          );
+        });
+      });
+
+      await Promise.all(promises);
+    };
+
+    loadProfileImages();
+  }, [cardData]);
+
   return (
     <CardContainer>
       {cardData.map((card) => (
@@ -277,19 +399,30 @@ function RollingPaperList({ cardData, totalPages, currentPage, onTurnCards }) {
           $backgroundColor={card.backgroundColor}
           $backgroundImageURL={card.backgroundImageURL}
         >
+          {card.backgroundImageURL && !imageLoadStates[card.id] && (
+            <Spinner size="50px" thickness="3px" />
+          )}
           <CardTitle
             $fontColor={card.backgroundImageURL ? "#ffffff" : "#000000"}
           >
             To. {card.name}
           </CardTitle>
           <ProfileContainer>
-            {card.recentMessages.slice(0, 3).map((messagecard, index) => (
-              <CardProfile
-                key={index}
-                src={messagecard.profileImageURL}
-                alt={`profile-${index}`}
-              />
-            ))}
+            {card.recentMessages
+              .slice(0, 3)
+              .map((messageCard, messageIndex) => (
+                <CardProfile $messageIndex={messageIndex}>
+                  <Avatar
+                    key={messageIndex}
+                    source={
+                      profileLoadStates[messageCard.id]
+                        ? messageCard.profileImageURL
+                        : null
+                    }
+                    size={AVATAR_SIZE.extraSmall}
+                  />
+                </CardProfile>
+              ))}
             {card.messageCount > 3 && (
               <OverProfile>
                 <span>+{card.messageCount - 3}</span>

--- a/src/pages/rolling-paper-list-page.jsx
+++ b/src/pages/rolling-paper-list-page.jsx
@@ -23,6 +23,8 @@ const CardSection = styled.section`
 
 const CardTitle = styled.h2`
   text-align: left;
+  font-size: 24px;
+  font-weight: 700;
 
   ${media.tablet} {
     margin-left: 24px;
@@ -30,6 +32,8 @@ const CardTitle = styled.h2`
 
   ${media.mobile} {
     margin-left: 20px;
+    font-size: 20px;
+    font-weight: 600;
   }
 `;
 
@@ -39,12 +43,13 @@ const MakingButton = styled(PrimaryButton)`
   padding: 14px 60px;
 
   ${media.tablet} {
-    position: absolute;
-    bottom: 24px;
     justify-self: anchor-center;
     margin-left: 24px;
     margin-right: 24px;
     width: calc(100% - 48px);
+    padding: 14px 20px;
+    position: relative;
+    bottom: 24px;
   }
 `;
 


### PR DESCRIPTION
## 📝 작업 내용

> 카드 배경이미지 로딩시에 스피너 (개별적으로 작동)
프로필 이미지 Avatar 공통컴포넌트 사용. 로딩시 기본 프로필이미지 보이고 로딩되고나면 이미지 보이도록 설정. (개별적으로 작동)
태블릿이나 모바일화면에서 카드 스크롤시 카드단위로 멈추도록.

## 📷 스크린샷 (선택)

> <img width="1242" height="633" alt="image" src="https://github.com/user-attachments/assets/4d85dbff-d382-4f5e-b400-34b0f4d38b2e" />
배경이미지 스피너

<img width="351" height="672" alt="image" src="https://github.com/user-attachments/assets/de9f789b-3ae0-4222-aecb-c7e11be528d1" />
프로필 이미지

## 🧐 해결해야 하는 문제 (선택)

> 

화면 세로길이가  길때
<img width="942" height="1129" alt="image" src="https://github.com/user-attachments/assets/4d487f2c-800a-469b-a10e-df465c07e97e" />

화면 세로길이가 짧을때
<img width="904" height="794" alt="image" src="https://github.com/user-attachments/assets/5803965f-bb42-4d50-ab16-8125acff921f" />

카드 아래까지만 버튼 따라오게 고정하기

