### PR TITLE
[#78, #84] Modal 개선 / 롤링 페이퍼 및 메시지 삭제 전에 확인 Dialog 표시

### DIFF
--- a/src/components/modal/modal-dialog.jsx
+++ b/src/components/modal/modal-dialog.jsx
@@ -1,0 +1,40 @@
+import styled from "styled-components";
+import { PrimaryButton } from "../button/button";
+import BUTTON_SIZE from "../button/button-size";
+import Colors from "../color/colors";
+
+const Title = styled.h2`
+  margin: 0;
+  color: ${Colors.gray(600)};
+`;
+
+const Content = styled.p`
+  margin: 0;
+  color: ${Colors.gray(600)};
+`;
+
+const Action = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 16px;
+`;
+
+const StyledAlertDialog = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+`;
+
+function ModalDialog({ title, content, action }) {
+  return (
+    <StyledAlertDialog>
+      <Title>{title}</Title>
+      {content && <Content>{content}</Content>}
+      <Action>
+        {action ?? <PrimaryButton size={BUTTON_SIZE.medium} title="확인" />}
+      </Action>
+    </StyledAlertDialog>
+  );
+}
+
+export default ModalDialog;

--- a/src/components/modal/modal.jsx
+++ b/src/components/modal/modal.jsx
@@ -1,7 +1,4 @@
 import styled from "styled-components";
-import { useModal } from "../../hooks/use-modal";
-import { PrimaryButton } from "../button/button";
-import BUTTON_SIZE from "../button/button-size";
 import Portal from "../portal/portal";
 
 const Content = styled.div`
@@ -34,34 +31,14 @@ const ModalContainer = styled.div`
   align-items: center;
 `;
 
-const ActionButton = styled.div`
-  cursor: pointer;
-`;
-
-function Modal({ id, action, children }) {
-  const { showsModal, setShowsModal } = useModal({
-    id: id,
-    type: "modal",
-  });
-
-  const handleClick = () => setShowsModal(true);
-  const handleConfirmClick = () => setShowsModal(false);
-
+function Modal({ shows, children }) {
   return (
     <>
-      <ActionButton onClick={handleClick}>{action}</ActionButton>
-      {showsModal && (
+      {shows && (
         <Portal id="modal">
           <ModalContainer>
             <StyledModal>
-              <Content>
-                {children}
-                <PrimaryButton
-                  size={BUTTON_SIZE.medium}
-                  title="확인"
-                  onClick={handleConfirmClick}
-                />
-              </Content>
+              <Content>{children}</Content>
             </StyledModal>
           </ModalContainer>
         </Portal>

--- a/src/features/message/components/message-card-detail.jsx
+++ b/src/features/message/components/message-card-detail.jsx
@@ -1,9 +1,12 @@
 import styled from "styled-components";
+import { PrimaryButton } from "../../../components/button/button";
+import BUTTON_SIZE from "../../../components/button/button-size";
 import Colors from "../../../components/color/colors";
 import { formatDate } from "../../../utils/formatter";
 import MessageSender from "./message-sender";
 
 const Header = styled.header`
+  width: 100%;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -12,6 +15,7 @@ const Header = styled.header`
 `;
 
 const Content = styled.div`
+  width: 100%;
   margin-top: 16px;
   font-size: 18px;
   font-weight: 400;
@@ -34,6 +38,10 @@ const Content = styled.div`
   }
 `;
 
+const Action = styled.div`
+  padding-top: 24px;
+`;
+
 const CreatedDate = styled.span`
   font-size: 14px;
   font-weight: 400;
@@ -41,9 +49,13 @@ const CreatedDate = styled.span`
   color: ${Colors.gray(400)};
 `;
 
-const StyledMessageCardDetail = styled.div``;
+const StyledMessageCardDetail = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
 
-function MessageCardDetail({ message }) {
+function MessageCardDetail({ message, onConfirm }) {
   return (
     <StyledMessageCardDetail>
       <Header>
@@ -55,6 +67,13 @@ function MessageCardDetail({ message }) {
         <CreatedDate>{formatDate(message.createdAt, ".")}</CreatedDate>
       </Header>
       <Content>{message.content}</Content>
+      <Action>
+        <PrimaryButton
+          size={BUTTON_SIZE.medium}
+          title="확인"
+          onClick={onConfirm}
+        />
+      </Action>
     </StyledMessageCardDetail>
   );
 }

--- a/src/features/message/components/message-card.jsx
+++ b/src/features/message/components/message-card.jsx
@@ -50,11 +50,22 @@ const StyledMessageCard = styled.article`
   border-radius: 16px;
   background-color: white;
   box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.08);
+  cursor: ${({ $isEditing }) => ($isEditing ? "default" : "pointer")};
 `;
 
-function MessageCard({ isEditing, message, onDelete }) {
+function MessageCard({ isEditing, message, onClick, onDelete }) {
+  const handleClick = () => {
+    if (isEditing) return;
+    onClick(message);
+  };
+
+  const handleDeleteClick = (event) => {
+    event.stopPropagation();
+    onDelete(message.id);
+  };
+
   return (
-    <StyledMessageCard>
+    <StyledMessageCard $isEditing={isEditing} onClick={handleClick}>
       <Header>
         <MessageSender
           profileImageUrl={message.profileImageURL}
@@ -65,7 +76,7 @@ function MessageCard({ isEditing, message, onDelete }) {
           <OutlinedButton
             size={BUTTON_SIZE.medium}
             icon={deleteImage}
-            onClick={onDelete}
+            onClick={handleDeleteClick}
           />
         )}
       </Header>

--- a/src/features/message/components/message-card.jsx
+++ b/src/features/message/components/message-card.jsx
@@ -61,7 +61,7 @@ function MessageCard({ isEditing, message, onClick, onDelete }) {
 
   const handleDeleteClick = (event) => {
     event.stopPropagation();
-    onDelete(message.id);
+    onDelete(message);
   };
 
   return (

--- a/src/features/message/components/messages-grid.jsx
+++ b/src/features/message/components/messages-grid.jsx
@@ -1,8 +1,9 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 import styled from "styled-components";
 import Modal from "../../../components/modal/modal.jsx";
 import { useIntersectionObserver } from "../../../hooks/use-intersection-observer.jsx";
+import { useModal } from "../../../hooks/use-modal.jsx";
 import { media } from "../../../utils/media.js";
 import MessageCardAdd from "./message-card-add.jsx";
 import MessageCardDetail from "./message-card-detail.jsx";
@@ -28,6 +29,10 @@ function MessagesGrid({ isEditing, messages, onDelete, onInfiniteScroll }) {
   const navigate = useNavigate();
   const { id } = useParams();
   const infiniteScrollTargetRef = useRef();
+  const { showsModal, setShowsModal } = useModal({
+    key: "message-modal",
+  });
+  const [modalMessage, setModalMessage] = useState(null);
 
   const observerCallback = (entry) => {
     if (!entry.isIntersecting) return;
@@ -39,33 +44,42 @@ function MessagesGrid({ isEditing, messages, onDelete, onInfiniteScroll }) {
     navigate(`/post/${id}/message`);
   };
 
+  const handleMessageClick = (message) => {
+    setShowsModal(true);
+    setModalMessage(message);
+  };
+
   const handleDeleteClick = (messageId) => {
     onDelete(messageId);
   };
 
-  const messageCard = (message) => (
-    <MessageCard
-      key={message.id}
-      isEditing={isEditing}
-      message={message}
-      onDelete={() => handleDeleteClick(message.id)}
-    />
-  );
+  const handleModalConfirm = () => {
+    setShowsModal(false);
+    setModalMessage(null);
+  };
 
   return (
-    <StyledRollingPaperMessagesGrid>
-      <MessageCardAdd onClick={handleAddClick} />
-      {messages.map((message) =>
-        isEditing ? (
-          messageCard(message)
-        ) : (
-          <Modal key={message.id} id={message.id} action={messageCard(message)}>
-            <MessageCardDetail message={message} />
-          </Modal>
-        )
-      )}
-      <div ref={infiniteScrollTargetRef}></div>
-    </StyledRollingPaperMessagesGrid>
+    <>
+      <StyledRollingPaperMessagesGrid>
+        <MessageCardAdd onClick={handleAddClick} />
+        {messages.map((message) => (
+          <MessageCard
+            key={message.id}
+            isEditing={isEditing}
+            message={message}
+            onClick={handleMessageClick}
+            onDelete={handleDeleteClick}
+          />
+        ))}
+        <div ref={infiniteScrollTargetRef}></div>
+      </StyledRollingPaperMessagesGrid>
+      <Modal shows={showsModal && modalMessage != null}>
+        <MessageCardDetail
+          message={modalMessage}
+          onConfirm={handleModalConfirm}
+        />
+      </Modal>
+    </>
   );
 }
 

--- a/src/features/message/components/messages-grid.jsx
+++ b/src/features/message/components/messages-grid.jsx
@@ -49,8 +49,8 @@ function MessagesGrid({ isEditing, messages, onDelete, onInfiniteScroll }) {
     setModalMessage(message);
   };
 
-  const handleDeleteClick = (messageId) => {
-    onDelete(messageId);
+  const handleDeleteClick = (message) => {
+    onDelete(message);
   };
 
   const handleModalConfirm = () => {

--- a/src/hooks/use-modal-dialog.jsx
+++ b/src/hooks/use-modal-dialog.jsx
@@ -1,0 +1,41 @@
+import { useState } from "react";
+import { useModal } from "./use-modal";
+
+function useModalDialog() {
+  const { showsModal, setShowsModal } = useModal({
+    key: "delete-modal",
+  });
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+  const [primaryAction, setPrimaryAction] = useState(null);
+
+  const openDialog = ({ title, content, primaryAction }) => {
+    setShowsModal(true);
+    setTitle(title);
+    setContent(content);
+    setPrimaryAction(() => primaryAction);
+  };
+
+  const closeDialog = () => {
+    setShowsModal(false);
+    setTitle("");
+    setContent("");
+    setPrimaryAction(null);
+  };
+
+  const onPrimaryAction = () => {
+    primaryAction();
+    closeDialog();
+  };
+
+  return {
+    showsDialog: showsModal,
+    dialogTitle: title,
+    dialogContent: content,
+    openDialog,
+    closeDialog,
+    onPrimaryAction,
+  };
+}
+
+export { useModalDialog };

--- a/src/hooks/use-modal.jsx
+++ b/src/hooks/use-modal.jsx
@@ -1,7 +1,6 @@
 import { usePortal } from "./use-portal";
 
-function useModal({ id, type }) {
-  const key = `${type}_${id}`;
+function useModal({ key }) {
   const { isOpen, setIsOpen } = usePortal({ key });
   return { showsModal: isOpen, setShowsModal: setIsOpen };
 }

--- a/src/pages/messages-page.jsx
+++ b/src/pages/messages-page.jsx
@@ -75,7 +75,7 @@ function ViewerButtons({ onEdit }) {
   );
 }
 
-function EditingButtons({ onDelete, onCancel }) {
+function EditingButtons({ onDelete, onDone }) {
   return (
     <ButtonContainer>
       <DangerousButton
@@ -86,7 +86,7 @@ function EditingButtons({ onDelete, onCancel }) {
       <OutlinedButton
         size={BUTTON_SIZE.medium}
         title="완료"
-        onClick={onCancel}
+        onClick={onDone}
       />
     </ButtonContainer>
   );
@@ -119,7 +119,7 @@ function MessagesPage() {
     }
   };
 
-  const handleEditCancel = () => {
+  const handleEditDone = () => {
     navigate(-1);
   };
 
@@ -186,7 +186,7 @@ function MessagesPage() {
               {isEditing ? (
                 <EditingButtons
                   onDelete={handleRollingPaperDelete}
-                  onCancel={handleEditCancel}
+                  onDone={handleEditDone}
                 />
               ) : (
                 <ViewerButtons onEdit={handleEditClick} />

--- a/src/pages/messages-page.jsx
+++ b/src/pages/messages-page.jsx
@@ -5,7 +5,6 @@ import {
   DangerousButton,
   OutlinedButton,
   PrimaryButton,
-  SecondaryButton,
 } from "../components/button/button";
 import BUTTON_SIZE from "../components/button/button-size";
 import BACKGROUND_COLOR from "../components/color/background-color";
@@ -82,7 +81,7 @@ function ViewerButtons({ onEdit }) {
 function EditingButtons({ onDelete, onDone }) {
   return (
     <ButtonContainer>
-      <DangerousButton
+      <PrimaryButton
         size={BUTTON_SIZE.medium}
         title="삭제하기"
         onClick={onDelete}
@@ -245,12 +244,12 @@ function MessagesPage() {
           content={dialogContent}
           action={
             <>
-              <PrimaryButton
+              <DangerousButton
                 size={BUTTON_SIZE.medium}
                 title="삭제"
                 onClick={handleDelete}
               />
-              <SecondaryButton
+              <OutlinedButton
                 size={BUTTON_SIZE.medium}
                 title="취소"
                 onClick={handleDeleteCancel}

--- a/src/tests/test-components-page.jsx
+++ b/src/tests/test-components-page.jsx
@@ -23,6 +23,7 @@ import POPOVER_ALIGNMENT from "../components/popover/popover-alignment";
 import TextField from "../components/text-field/text-field";
 import TEXT_FIELD_TYPE from "../components/text-field/text-field-type";
 import Toast from "../components/toast/toast";
+import { useModal } from "../hooks/use-modal";
 import { useToast } from "../hooks/use-toast";
 
 const OutlinedHeader = styled(Header)`
@@ -48,6 +49,13 @@ function TestComponentsPage() {
 
   const handleToastClick = () => setShowsToast(true);
   const handleToastDismiss = () => setShowsToast(false);
+
+  /* Modal */
+  const { showsModal, setShowsModal } = useModal({
+    key: "test-modal",
+  });
+  const handleModalOpen = () => setShowsModal(true);
+  const handleModalClose = () => setShowsModal(false);
 
   return (
     <div
@@ -207,11 +215,18 @@ function TestComponentsPage() {
         )}
       </div>
       <div>
-        <Modal
-          id="user"
-          action={<PrimaryButton size={BUTTON_SIZE.small} title="Show Modal" />}
-        >
+        <PrimaryButton
+          size={BUTTON_SIZE.small}
+          title="Show Modal"
+          onClick={handleModalOpen}
+        />
+        <Modal shows={showsModal}>
           <h1>This is Modal.</h1>
+          <PrimaryButton
+            size={BUTTON_SIZE.small}
+            title={"Close"}
+            onClick={handleModalClose}
+          />
         </Modal>
       </div>
       <div style={{ display: "flex", gap: "16px" }}>


### PR DESCRIPTION
## 📝 작업 내용

- 롤링 페이퍼와 메시지 삭제 버튼을 클릭했을 때 즉시 삭제하지 않고 사용자에게 한번 더 물어보는 modal dialog를 표시합니다.
- #91 PR의 내용을 포함합니다.

## 📷 스크린샷 (선택)

<img width="650" height="263" alt="image" src="https://github.com/user-attachments/assets/97bf71eb-e89f-4e59-9a8a-a7b19d1c3ce6" />

<img width="650" height="263" alt="image" src="https://github.com/user-attachments/assets/b9493759-7813-4393-a7b3-c4bd762cfead" />