### PR TITLE
[#92] Header logo를 클릭했을 때 메인 페이지로 이동

### DIFF
--- a/src/components/header/header.jsx
+++ b/src/components/header/header.jsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router";
 import styled from "styled-components";
 import logoImage from "../../assets/logo.svg";
 import { media } from "../../utils/media";
@@ -27,7 +28,9 @@ function Header({ className, children }) {
   return (
     <StyledHeader className={className}>
       <HeaderContent>
-        <img src={logoImage} alt="로고" />
+        <Link to="/">
+          <img src={logoImage} alt="로고" />
+        </Link>
         <div>{children}</div>
       </HeaderContent>
     </StyledHeader>

--- a/src/layouts/onboarding-layout.jsx
+++ b/src/layouts/onboarding-layout.jsx
@@ -1,7 +1,23 @@
 import { useNavigate } from "react-router";
+import styled from "styled-components";
 import { OutlinedButton } from "../components/button/button";
 import BUTTON_SIZE from "../components/button/button-size";
 import Header from "../components/header/header";
+
+const LayoutHeader = styled(Header)`
+  flex-shrink: 0;
+`;
+
+const Main = styled.main`
+  flex-grow: 1;
+  min-height: 100vh - 64px;
+`;
+
+const StyledOnbardingLayout = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+`;
 
 function OnboardingLayout({ children }) {
   const navigate = useNavigate();
@@ -9,16 +25,16 @@ function OnboardingLayout({ children }) {
   const handlePostCreate = () => navigate("/post");
 
   return (
-    <>
-      <Header>
+    <StyledOnbardingLayout>
+      <LayoutHeader>
         <OutlinedButton
           size={BUTTON_SIZE.medium}
           title="롤링 페이퍼 만들기"
           onClick={handlePostCreate}
         />
-      </Header>
-      <main>{children}</main>
-    </>
+      </LayoutHeader>
+      <Main>{children}</Main>
+    </StyledOnbardingLayout>
   );
 }
 

--- a/src/pages/rolling-paper-list-page.jsx
+++ b/src/pages/rolling-paper-list-page.jsx
@@ -71,7 +71,7 @@ function getCachedImage(url) {
   return cache[url].src;
 }
 
-function ShowMessageList() {
+function RollingPaperListPage() {
   const navigate = useNavigate();
 
   const [recipientsData, setRecipientsData] = useState([]);
@@ -187,4 +187,4 @@ function ShowMessageList() {
   );
 }
 
-export default ShowMessageList;
+export default RollingPaperListPage;

--- a/src/pages/rolling-paper-list-page.jsx
+++ b/src/pages/rolling-paper-list-page.jsx
@@ -1,17 +1,16 @@
-import { PrimaryButton } from "../components/button/button";
-import BUTTON_SIZE from "../components/button/button-size";
-import React, { useEffect, useState, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import styled from "styled-components";
-import RollingPaperList from "../features/rolling-paper/components/rolling-paper-list";
-import { media } from "../utils/media";
-import { useMedia } from "../hooks/use-media";
 import { apiClient } from "../api/client";
+import { PrimaryButton } from "../components/button/button";
+import BUTTON_SIZE from "../components/button/button-size";
+import RollingPaperList from "../features/rolling-paper/components/rolling-paper-list";
+import { useMedia } from "../hooks/use-media";
+import { media } from "../utils/media";
 
 const TopContainer = styled.div`
   text-align: center;
   margin-top: 50px;
-  min-height: calc(100vh - 64px);
   display: flex;
   flex-direction: column;
 `;


### PR DESCRIPTION
## 📝 작업 내용

- 모든 페이지에서 header의 logo를 클릭하면 메인 페이지(`/`)로 이동하도록 구현합니다.

## 💬 리뷰어에게 남길 말 (선택)

- @nidor022
  - `RollingPaperListPage`에서 header를 제외한 영역을 viewport에 꽉 차게 늘리도록 수정하신 것을 확인했습니다.
    - 컨텐츠가 화면을 넘어가지 않았는데도 오른쪽에 스크롤이 생기는 문제가 있어서 관련 내용을 수정했습니다.
    - `RollingPaperListPage`의 `TopContainer`에 `min-height` 속성을 제거하고, `OnboardingLayout`에서 `<main>` 영역에 높이를 지정하도록 수정했습니다.
    - 이렇게 수정하면, `RollingPaperListPage` 외에 `MainPage`에서도 같은 효과를 볼 수 있습니다.
  - `rolling-paper-list-page.jsx` 파일이 export하는 component 이름을 파일 이름과 동일하게 수정했습니다.
    - `ShowMessageList` -> `RollingPaperListPage`
