### PR TITLE
[#110] 이미지 로딩 중 배경 색상 표시

### DIFF
--- a/src/components/avatar/avatar.jsx
+++ b/src/components/avatar/avatar.jsx
@@ -19,8 +19,9 @@ const avatarStyle = css`
 
 const StyledAvatar = styled.div`
   ${avatarStyle}
-  border: ${({ $size }) => borderWidth[`${$size}`]}px solid ${({ $color }) =>
-    $color};
+  background-color: ${Colors.gray(200)};
+  border: ${({ $size }) => borderWidth[`${$size}`]}px solid
+    ${({ $color }) => $color};
 
   img {
     width: 100%;

--- a/src/components/avatar/avatar.jsx
+++ b/src/components/avatar/avatar.jsx
@@ -1,6 +1,8 @@
+import { useState } from "react";
 import styled, { css } from "styled-components";
 import defaultAvatarImage from "../../assets/ic-person.svg";
 import Colors from "../color/colors";
+import SkeletonLoading from "../loading/skeleton-loading";
 import AVATAR_SIZE from "./avatar-size";
 
 const borderWidth = {
@@ -19,7 +21,6 @@ const avatarStyle = css`
 
 const StyledAvatar = styled.div`
   ${avatarStyle}
-  background-color: ${Colors.gray(200)};
   border: ${({ $size }) => borderWidth[`${$size}`]}px solid
     ${({ $color }) => $color};
 
@@ -47,10 +48,22 @@ function Avatar({
   size = AVATAR_SIZE.medium,
   color = Colors.gray(200),
 }) {
-  const img = <img src={source ?? defaultAvatarImage} alt="사용자 사진" />;
+  const [isLoading, setLoading] = useState(source ?? false);
+  const handleImageLoad = () => {
+    setLoading(false);
+  };
+
+  const img = (
+    <img
+      src={source ?? defaultAvatarImage}
+      alt="사용자 사진"
+      onLoad={handleImageLoad}
+    />
+  );
+
   return source ? (
     <StyledAvatar $size={size} $color={color}>
-      {img}
+      <SkeletonLoading isLoading={isLoading}>{img}</SkeletonLoading>
     </StyledAvatar>
   ) : (
     <StyledDefaultAvatar $size={size}>{img}</StyledDefaultAvatar>

--- a/src/components/loading/skeleton-loading.jsx
+++ b/src/components/loading/skeleton-loading.jsx
@@ -1,0 +1,37 @@
+import styled, { keyframes } from "styled-components";
+import Colors from "../color/colors";
+
+const LoadingAnimation = keyframes`
+  from {
+    background-position-x: 100%;
+  }
+
+  to {
+    background-position-x: 0%;
+  }
+`;
+
+const StyledSkeletonLoading = styled.div`
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(
+    to left,
+    ${Colors.gray(200)} 40%,
+    white 50%,
+    ${Colors.gray(200)} 60%
+  );
+  background-size: 300% 100%;
+  background-repeat: no-repeat;
+  animation: ${({ $isLoading }) => ($isLoading ? LoadingAnimation : "none")} 2s
+    infinite;
+`;
+
+function SkeletonLoading({ isLoading, children }) {
+  return (
+    <StyledSkeletonLoading $isLoading={isLoading}>
+      {children}
+    </StyledSkeletonLoading>
+  );
+}
+
+export default SkeletonLoading;

--- a/src/pages/messages-page.jsx
+++ b/src/pages/messages-page.jsx
@@ -26,21 +26,7 @@ import { useModalDialog } from "../hooks/use-modal-dialog";
 import ContentLayout from "../layouts/content-layout";
 import { media } from "../utils/media";
 
-const backgroundStyle = ({ $backgroundImageUrl, $backgroundColor }) => {
-  if (!$backgroundImageUrl) {
-    return `background-color: ${$backgroundColor}`;
-  }
-
-  return `
-    background: url('${$backgroundImageUrl}');
-    background-size: contain;
-  `;
-};
-
 const Content = styled.div`
-  ${backgroundStyle};
-  height: calc(100% - 68px);
-
   & > div {
     display: flex;
     flex-direction: column;
@@ -58,6 +44,22 @@ const Content = styled.div`
       padding: 24px 20px 38px;
     }
   }
+`;
+
+const BackgroundColor = styled.div`
+  height: calc(100% - 68px);
+  background-color: ${({ $backgroundColor }) =>
+    $backgroundColor ?? BACKGROUND_COLOR.beige};
+`;
+
+const BackgroundImage = styled.div`
+  ${({ $backgroundImageUrl }) =>
+    $backgroundImageUrl
+      ? `
+          background: url('${$backgroundImageUrl}');
+          background-size: contain;
+        `
+      : ""}
 `;
 
 const ButtonContainer = styled.div`
@@ -207,27 +209,30 @@ function MessagesPage() {
             recipientName={recipient.name}
             messages={messages}
           />
-          <Content
-            $backgroundImageUrl={recipient.backgroundImageURL}
+          <BackgroundColor
             $backgroundColor={BACKGROUND_COLOR[recipient.backgroundColor]}
           >
-            <div>
-              {isEditing ? (
-                <EditingButtons
-                  onDelete={handleRollingPaperDelete}
-                  onDone={handleEditDone}
-                />
-              ) : (
-                <ViewerButtons onEdit={handleEditClick} />
-              )}
-              <MessagesGrid
-                isEditing={isEditing}
-                messages={messages}
-                onDelete={handleMessageDelete}
-                onInfiniteScroll={handleInfiniteScroll}
-              />
-            </div>
-          </Content>
+            <BackgroundImage $backgroundImageUrl={recipient.backgroundImageURL}>
+              <Content>
+                <div>
+                  {isEditing ? (
+                    <EditingButtons
+                      onDelete={handleRollingPaperDelete}
+                      onDone={handleEditDone}
+                    />
+                  ) : (
+                    <ViewerButtons onEdit={handleEditClick} />
+                  )}
+                  <MessagesGrid
+                    isEditing={isEditing}
+                    messages={messages}
+                    onDelete={handleMessageDelete}
+                    onInfiniteScroll={handleInfiniteScroll}
+                  />
+                </div>
+              </Content>
+            </BackgroundImage>
+          </BackgroundColor>
         </>
       )}
     </>


### PR DESCRIPTION
## 📝 작업 내용

- 롤링 페이퍼 배경 이미지를 로딩 중에 색상을 미리 보여줍니다.
- 프로필 이미지를 로딩 중에 스켈레톤 로딩 animation을 보여줍니다.

## 📷 스크린샷 (선택)

<img width="416" height="603" alt="image" src="https://github.com/user-attachments/assets/8dae25db-0b3d-4c47-b18f-6d3156f233f5" />

## 👀 새로 알게 된 내용 (선택)

- Content 로딩이 끝나지 않았을 때, content가 나타날 위치와 형태를 미리 보여주는 방식으로 스켈레톤 애니메이션을 주로 사용합니다.
- 프로필 이미지와 배경 이미지로 사용하는 picsum 이미지는 로딩에 시간이 오래 걸리기 때문에 스켈레톤 애니메이션을 적용하기 좋은 케이스입니다.
- [css 속성들을 이해하면서 Skeleton 만들기](https://yogjin.tistory.com/116) 블로그 글을 참고해서 구현했습니다.
- 스켈레톤 애니메이션을 구현하기 위해 필요한 주요 CSS 속성들은 아래와 같습니다.
  - `background` : `linear-gradient`를 설정해서 스켈레톤 애니메이션으로 보여줄 배경을 설정합니다.
  - `background-size` : gradient 배경의 가로 너비를 크게 늘립니다. 늘어날 배경을 움직여서 애니메이션을 구현합니다.
  - `background-repeat` : `no-repeat`으로 설정해서 background가 하나만 표시되도록 합니다.
  - `background-position` : gradient 배경을 animation으로 이동시킵니다.

## 💬 리뷰어에게 남길 말 (선택)

- @nidor022 님이 만드셨던 spinner 로딩 애니메이션이 작은 프로필 이미지에 사용하기 어려울 것 같다고 생각돼서 스켈레톤 애니메이션을 따로 구현해 보았습니다.
- 혹시 이미지를 로딩하는 부분에 spinner가 어울리지 않는다면 이 애니메이션을 적용해 보아도 좋겠습니다.
